### PR TITLE
Tighten auth bootstrap handling

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -24,13 +24,17 @@ public class AuthController(
         var displayName = request.DisplayName.Trim();
         var email = request.Email.Trim().ToLowerInvariant();
 
-        var exists = await dbContext.Players.AnyAsync(p => p.DisplayName == displayName);
+        var exists = await dbContext.Players
+            .AsNoTracking()
+            .AnyAsync(p => p.DisplayName == displayName);
         if (exists)
         {
             return Conflict(new { message = "Display name is already taken." });
         }
 
-        var emailExists = await dbContext.Players.AnyAsync(p => p.Email == email);
+        var emailExists = await dbContext.Players
+            .AsNoTracking()
+            .AnyAsync(p => p.Email == email);
         if (emailExists)
         {
             return Conflict(new { message = "Email is already registered." });
@@ -58,7 +62,9 @@ public class AuthController(
     {
         var email = request.Email.Trim().ToLowerInvariant();
 
-        var player = await dbContext.Players.FirstOrDefaultAsync(p => p.Email == email);
+        var player = await dbContext.Players
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Email == email);
 
         if (player is null)
         {
@@ -85,7 +91,9 @@ public class AuthController(
             return Unauthorized();
         }
 
-        var player = await dbContext.Players.FirstOrDefaultAsync(p => p.Id == playerId);
+        var player = await dbContext.Players
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == playerId);
         if (player is null)
         {
             return Unauthorized();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -67,7 +67,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret)),
+            IssuerSigningKey = new SymmetricSecurityKey(secretBytes),
             ValidateIssuer = true,
             ValidateAudience = true,
             ValidIssuer = issuer,

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
@@ -1,76 +1,93 @@
 import { AuthService } from '$lib/api-client/services/AuthService';
 import { configureApiClient } from '$lib/api';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { AuthResponse, AuthState } from './types';
 
 const TOKEN_STORAGE_KEY = 'wts_auth_token';
 
+const initialToken = loadStoredToken();
+
 function loadStoredToken(): string | null {
-	if (typeof localStorage === 'undefined') return null;
-	return localStorage.getItem(TOKEN_STORAGE_KEY);
+  if (typeof localStorage === 'undefined') return null;
+
+  try {
+    return localStorage.getItem(TOKEN_STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to load auth token from storage', error);
+    return null;
+  }
 }
 
 function persistToken(token: string | null) {
-	if (typeof localStorage === 'undefined') return;
-	if (token) {
-		localStorage.setItem(TOKEN_STORAGE_KEY, token);
-	} else {
-		localStorage.removeItem(TOKEN_STORAGE_KEY);
-	}
+  if (typeof localStorage === 'undefined') return;
+
+  try {
+    if (token) {
+      localStorage.setItem(TOKEN_STORAGE_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.error('Failed to persist auth token', error);
+  }
 }
 
 export const auth = writable<AuthState>({
-	user: null,
-	token: loadStoredToken(),
-	ready: false
+  user: null,
+  token: initialToken,
+  ready: false,
+  error: null
 });
 
-configureApiClient(loadStoredToken());
+configureApiClient(initialToken);
 
 function setAuthenticated(result: AuthResponse) {
-	persistToken(result.token);
-	configureApiClient(result.token);
-	auth.set({
-		user: result.player,
-		token: result.token,
-		ready: true,
-		error: null
-	});
+  persistToken(result.token);
+  configureApiClient(result.token);
+  auth.set({
+    user: result.player,
+    token: result.token,
+    ready: true,
+    error: null
+  });
+}
+
+function clearAuth(error: string | null = null) {
+  persistToken(null);
+  configureApiClient(null);
+  auth.set({ user: null, token: null, ready: true, error });
 }
 
 export async function bootstrapAuth() {
-	let token = loadStoredToken();
-	if (!token) {
-		auth.set({ user: null, token: null, ready: true });
-		return;
-	}
+  const token = get(auth).token;
+  if (!token) {
+    clearAuth();
+    return;
+  }
 
-	configureApiClient(token);
+  configureApiClient(token);
 
-	try {
-		const player = await AuthService.getApiAuthMe();
-		auth.set({ user: player, token, ready: true, error: null });
-	} catch (error) {
-		console.error('Auth bootstrap failed', error);
-		persistToken(null);
-		auth.set({ user: null, token: null, ready: true, error: 'Session expired. Please sign in.' });
-	}
+  try {
+    const player = await AuthService.getApiAuthMe();
+    auth.set({ user: player, token, ready: true, error: null });
+  } catch (error) {
+    console.error('Auth bootstrap failed', error);
+    clearAuth('Session expired. Please sign in.');
+  }
 }
 
 export async function signIn(email: string, password: string) {
-	const result = await AuthService.postApiAuthSignin({
-		requestBody: { email, password }
-	});
-	setAuthenticated(result);
+  const result = await AuthService.postApiAuthSignin({
+    requestBody: { email, password }
+  });
+  setAuthenticated(result);
 }
 
 export async function signUp(displayName: string, email: string, password: string) {
-	const result = await AuthService.postApiAuthSignup({ requestBody: { displayName, email, password } });
-	setAuthenticated(result);
+  const result = await AuthService.postApiAuthSignup({ requestBody: { displayName, email, password } });
+  setAuthenticated(result);
 }
 
 export function signOut() {
-	persistToken(null);
-	configureApiClient(null);
-	auth.set({ user: null, token: null, ready: true, error: null });
+  clearAuth();
 }

--- a/src/Wordle.TrackerSupreme.Web/src/routes/signin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/signin/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+import { goto } from '$app/navigation';
 import { auth, signIn } from '$lib/auth/store';
 import { onMount } from 'svelte';
 
@@ -8,32 +8,32 @@ let password = '';
 let error: string | null = null;
 let loading = false;
 
-	onMount(() => {
-		const unsubscribe = auth.subscribe((state) => {
-			if (!state.ready) return;
-			if (state.user) {
-				goto('/');
-			}
-		});
-		return () => unsubscribe();
-	});
+onMount(() => {
+  const unsubscribe = auth.subscribe((state) => {
+    if (!state.ready) return;
+    if (state.user) {
+      goto('/');
+    }
+  });
+  return () => unsubscribe();
+});
 
-	const handleSubmit = async () => {
-		error = null;
-		if (!email.trim()) {
-			error = 'Enter your email.';
-			return;
-		}
-		loading = true;
-		try {
-			await signIn(email, password);
-			goto('/');
-		} catch (err) {
-			error = err instanceof Error ? err.message : 'Unable to sign in.';
-		} finally {
-			loading = false;
-		}
-	};
+const handleSubmit = async () => {
+  error = null;
+  if (!email.trim()) {
+    error = 'Enter your email.';
+    return;
+  }
+  loading = true;
+  try {
+    await signIn(email, password);
+    goto('/');
+  } catch (err) {
+    error = err instanceof Error ? err.message : 'Unable to sign in.';
+  } finally {
+    loading = false;
+  }
+};
 </script>
 
 <div class="mx-auto max-w-lg rounded-3xl border border-white/10 bg-white/5 p-10 shadow-2xl">

--- a/src/Wordle.TrackerSupreme.Web/src/routes/signup/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/signup/+page.svelte
@@ -1,42 +1,42 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { auth, signUp } from '$lib/auth/store';
-	import { onMount } from 'svelte';
+import { goto } from '$app/navigation';
+import { auth, signUp } from '$lib/auth/store';
+import { onMount } from 'svelte';
 
 let displayName = '';
 let email = '';
 let password = '';
 let confirmPassword = '';
-	let error: string | null = null;
-	let loading = false;
+let error: string | null = null;
+let loading = false;
 
-	onMount(() => {
-		const unsubscribe = auth.subscribe((state) => {
-			if (!state.ready) return;
-			if (state.user) {
-				goto('/');
-			}
-		});
-		return () => unsubscribe();
-	});
+onMount(() => {
+  const unsubscribe = auth.subscribe((state) => {
+    if (!state.ready) return;
+    if (state.user) {
+      goto('/');
+    }
+  });
+  return () => unsubscribe();
+});
 
-	const handleSubmit = async () => {
-		error = null;
-		if (password !== confirmPassword) {
-			error = 'Passwords do not match.';
-			return;
-		}
+const handleSubmit = async () => {
+  error = null;
+  if (password !== confirmPassword) {
+    error = 'Passwords do not match.';
+    return;
+  }
 
-		loading = true;
-		try {
-			await signUp(displayName, email, password);
-			goto('/');
-		} catch (err) {
-			error = err instanceof Error ? err.message : 'Unable to sign up.';
-		} finally {
-			loading = false;
-		}
-	};
+  loading = true;
+  try {
+    await signUp(displayName, email, password);
+    goto('/');
+  } catch (err) {
+    error = err instanceof Error ? err.message : 'Unable to sign up.';
+  } finally {
+    loading = false;
+  }
+};
 </script>
 
 <div class="mx-auto max-w-lg rounded-3xl border border-white/10 bg-white/5 p-10 shadow-2xl">


### PR DESCRIPTION
## Summary
- reuse a single loaded token for initial auth state and API client configuration
- centralize auth clearing to keep client config and persisted token in sync during sign-out or expired sessions
- normalize auth page scripts with consistent indentation for readability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944eebef1dc83278122b272ce481e91)