### PR TITLE
Fix issue #6: include guesses in player attempt queries

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
@@ -14,6 +14,8 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
         => dbContext.Players
             .Include(p => p.Attempts)
                 .ThenInclude(a => a.DailyPuzzle)
+            .Include(p => p.Attempts)
+                .ThenInclude(a => a.Guesses)
             .FirstOrDefaultAsync(p => p.Id == playerId, cancellationToken);
 
     public Task<Player?> GetPlayerWithAttemptsAndGuesses(Guid playerId, CancellationToken cancellationToken)
@@ -32,6 +34,8 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
         => dbContext.Players
             .Include(p => p.Attempts)
                 .ThenInclude(a => a.DailyPuzzle)
+            .Include(p => p.Attempts)
+                .ThenInclude(a => a.Guesses)
             .ToListAsync(cancellationToken);
 
     public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerRepositoryTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerRepositoryTests.cs
@@ -10,7 +10,7 @@ namespace Wordle.TrackerSupreme.Tests;
 public class PlayerRepositoryTests
 {
     [Fact]
-    public async Task GetPlayersWithAttempts_includes_attempts_and_puzzles()
+    public async Task GetPlayersWithAttempts_includes_attempts_puzzles_and_guesses()
     {
         var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
             .UseInMemoryDatabase($"players-{Guid.NewGuid()}")
@@ -41,7 +41,16 @@ public class PlayerRepositoryTests
             PlayedInHardMode = true,
             CreatedOn = puzzle.PuzzleDate.ToDateTime(TimeOnly.MinValue)
         };
+        var guess = new GuessAttempt
+        {
+            Id = Guid.NewGuid(),
+            PlayerPuzzleAttempt = attempt,
+            PlayerPuzzleAttemptId = attempt.Id,
+            GuessNumber = 1,
+            GuessWord = "CRANE"
+        };
 
+        attempt.Guesses.Add(guess);
         player.Attempts.Add(attempt);
         puzzle.Attempts.Add(attempt);
 
@@ -49,6 +58,7 @@ public class PlayerRepositoryTests
         {
             context.Add(player);
             context.Add(puzzle);
+            context.Add(guess);
             await context.SaveChangesAsync();
         }
 
@@ -61,6 +71,70 @@ public class PlayerRepositoryTests
         var loaded = players.Single();
         loaded.Attempts.Should().ContainSingle();
         loaded.Attempts.First().DailyPuzzle.Should().NotBeNull();
+        loaded.Attempts.First().Guesses.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetPlayerWithAttempts_includes_guesses()
+    {
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseInMemoryDatabase($"players-{Guid.NewGuid()}")
+            .Options;
+
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Attempt Tester",
+            Email = "attempt@example.com",
+            PasswordHash = "hash",
+            Attempts = []
+        };
+        var puzzle = new DailyPuzzle
+        {
+            Id = Guid.NewGuid(),
+            PuzzleDate = new DateOnly(2025, 1, 4),
+            Solution = "CRANE"
+        };
+        var attempt = new PlayerPuzzleAttempt
+        {
+            Id = Guid.NewGuid(),
+            Player = player,
+            PlayerId = player.Id,
+            DailyPuzzle = puzzle,
+            DailyPuzzleId = puzzle.Id,
+            Status = AttemptStatus.InProgress,
+            PlayedInHardMode = true,
+            CreatedOn = puzzle.PuzzleDate.ToDateTime(TimeOnly.MinValue)
+        };
+        var guess = new GuessAttempt
+        {
+            Id = Guid.NewGuid(),
+            PlayerPuzzleAttempt = attempt,
+            PlayerPuzzleAttemptId = attempt.Id,
+            GuessNumber = 1,
+            GuessWord = "CRANE"
+        };
+
+        attempt.Guesses.Add(guess);
+        player.Attempts.Add(attempt);
+        puzzle.Attempts.Add(attempt);
+
+        await using (var context = new WordleTrackerSupremeDbContext(options))
+        {
+            context.Add(player);
+            context.Add(puzzle);
+            context.Add(guess);
+            await context.SaveChangesAsync();
+        }
+
+        await using var readContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new PlayerRepository(readContext);
+
+        var loaded = await repository.GetPlayerWithAttempts(player.Id, CancellationToken.None);
+
+        loaded.Should().NotBeNull();
+        loaded!.Attempts.Should().ContainSingle();
+        loaded.Attempts.First().Guesses.Should().ContainSingle();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Player statistics (average guesses) were computed from `PlayerPuzzleAttempt.GuessCount`, which remains 0 when the `Guesses` navigation property is not loaded, causing averages to be reported incorrectly.

### Description
- Eager-load `Guesses` on player queries by adding `.Include(p => p.Attempts).ThenInclude(a => a.Guesses)` to `GetPlayerWithAttempts` and `GetPlayersWithAttempts` in `PlayerRepository`.
- Left existing `GetPlayerWithAttemptsAndGuesses` intact (it already loads `Guesses` and `Feedback`).
- Updated `PlayerRepository` unit tests: renamed/expanded the `GetPlayersWithAttempts` test to assert guesses are included and added a new `GetPlayerWithAttempts_includes_guesses` test to validate single-player fetch behavior.

### Testing
- Attempted to run the backend test suite via `docker compose --profile tests run --rm tests-backend`, but the environment lacks `docker` so the run failed.
- Attempted to run targeted tests via `dotnet test --filter PlayerRepositoryTests`, but the environment lacks the `dotnet` SDK so the run failed.
- New/updated xUnit tests were added to `Wordle.TrackerSupreme.Tests` but could not be executed in this environment; they should pass when run in CI or a local dev environment with `dotnet` and Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd3134ec48327a4ab8b5a14acfaa8)