### PR TITLE
fix: prevent double submits by disabling game buttons while submitting

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/playwright.e2e.config.ts
+++ b/src/Wordle.TrackerSupreme.Web/playwright.e2e.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const artifactRoot =
 	process.env.E2E_ARTIFACT_DIR ?? path.resolve(__dirname, '../../artifacts/e2e/playwright');

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -343,7 +343,8 @@
 						onclick={handleEnableEasyMode}
 						disabled={!state ||
 							!state.isHardMode ||
-							(state.attempt && state.attempt.status !== 'InProgress')}
+							(state.attempt && state.attempt.status !== 'InProgress') ||
+							submitting}
 						data-testid="enable-easy-mode"
 					>
 						Enable easy mode
@@ -411,7 +412,7 @@
 										<button
 											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
 											onclick={removeLetter}
-											disabled={!state.canGuess}
+											disabled={!state.canGuess || submitting}
 										>
 											Back
 										</button>
@@ -420,7 +421,7 @@
 										<button
 											class={keyClass(letter)}
 											onclick={() => pushLetter(letter)}
-											disabled={!state.canGuess}
+											disabled={!state.canGuess || submitting}
 										>
 											{letter}
 										</button>
@@ -429,7 +430,7 @@
 										<button
 											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
 											onclick={submitFromKeyboard}
-											disabled={!state.canGuess}
+											disabled={!state.canGuess || submitting}
 										>
 											Enter
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -100,13 +100,12 @@
 	}
 
 	async function handleGuess() {
-		if (!state || submitting) {
+		if (isGuessInputLocked()) {
 			return;
 		}
-		if (!state.canGuess) {
-			return;
-		}
-		const targetLength = state.wordLength ?? 5;
+
+		const currentState = state!;
+		const targetLength = currentState.wordLength ?? 5;
 
 		const normalized = guess.trim().toUpperCase();
 
@@ -117,7 +116,7 @@
 
 		error = null;
 		message = null;
-		const previousStatus = state.attempt?.status ?? null;
+		const previousStatus = currentState.attempt?.status ?? null;
 		submitting = true;
 		try {
 			state = await submitGuess(normalized);
@@ -134,37 +133,48 @@
 		}
 	}
 
+	function isGuessInputLocked() {
+		return !state || !state.canGuess || submitting;
+	}
+
 	function pushLetter(letter: string) {
-		if (!state || !state.canGuess) {
+		if (isGuessInputLocked()) {
 			return;
 		}
-		if (guess.length >= state.wordLength) {
+
+		const currentState = state!;
+		if (guess.length >= currentState.wordLength) {
 			return;
 		}
+
 		guess = `${guess}${letter}`;
 	}
 
 	function removeLetter() {
-		if (!state || !guess.length) {
+		if (!state || !guess.length || submitting) {
 			return;
 		}
+
 		guess = guess.slice(0, -1);
 	}
 
 	function submitFromKeyboard() {
-		if (!state || !state.canGuess || submitting) {
+		if (isGuessInputLocked()) {
 			return;
 		}
+
 		void handleGuess();
 	}
 
 	async function handleEnableEasyMode() {
-		if (!state || !state.isHardMode) {
+		if (!state || !state.isHardMode || submitting) {
 			return;
 		}
+
 		if (state.attempt && state.attempt.status !== 'InProgress') {
 			return;
 		}
+
 		error = null;
 		message = null;
 		try {
@@ -412,7 +422,8 @@
 										<button
 											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
 											onclick={removeLetter}
-											disabled={!state.canGuess || submitting}
+											disabled={isGuessInputLocked()}
+											data-testid="remove-letter"
 										>
 											Back
 										</button>
@@ -421,7 +432,8 @@
 										<button
 											class={keyClass(letter)}
 											onclick={() => pushLetter(letter)}
-											disabled={!state.canGuess || submitting}
+											disabled={isGuessInputLocked()}
+											data-testid={`keyboard-key-${letter}`}
 										>
 											{letter}
 										</button>
@@ -430,7 +442,8 @@
 										<button
 											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
 											onclick={submitFromKeyboard}
-											disabled={!state.canGuess || submitting}
+											disabled={isGuessInputLocked()}
+											data-testid="submit-guess"
 										>
 											Enter
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/game-easy-mode.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/game-easy-mode.spec.ts
@@ -13,3 +13,46 @@ test('player can enable easy mode for the daily puzzle', async ({ page }) => {
 	await page.getByTestId('enable-easy-mode').click();
 	await expect(page.getByText('Easy mode enabled for this puzzle.')).toBeVisible();
 });
+
+test('guess controls stay locked while a guess is submitting', async ({ page }) => {
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E Submit ${nonce}`,
+		email: `e2e.submit.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await page.getByText('Loading today’s puzzle...').waitFor({ state: 'hidden' });
+
+	let guessRequests = 0;
+	let resolveGuessResponse!: () => void;
+	const guessResponseCompleted = new Promise<void>((resolve) => {
+		resolveGuessResponse = resolve;
+	});
+	await page.route('**/api/game/guess', async (route) => {
+		guessRequests += 1;
+		await page.waitForTimeout(400);
+		const response = await route.fetch();
+		await route.fulfill({ response });
+		resolveGuessResponse();
+	});
+
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	const submitPromise = page.keyboard.press('Enter');
+
+	await expect.poll(() => guessRequests).toBe(1);
+	await expect(page.getByTestId('submit-guess')).toBeDisabled();
+	await expect(page.getByTestId('remove-letter')).toBeDisabled();
+	await expect(page.getByTestId('enable-easy-mode')).toBeDisabled();
+
+	await page.keyboard.press('Backspace');
+	await expect(page.getByTestId('board-row-0')).toContainText('CRANE');
+	await page.keyboard.press('Enter');
+	await expect.poll(() => guessRequests).toBe(1);
+
+	await submitPromise;
+	await guessResponseCompleted;
+	await expect.poll(() => guessRequests).toBe(1);
+	await page.unroute('**/api/game/guess');
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
@@ -87,11 +87,125 @@ test('submitting a guess only calls the API once', async ({ page }) => {
 	});
 
 	await page.goto('/', { waitUntil: 'domcontentloaded' });
-	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
 
 	await page.click('body');
 	await page.keyboard.type('CRANE');
 	await page.keyboard.press('Enter');
 
+	await expect.poll(() => guessRequests).toBe(1);
+});
+
+test('guess controls stay locked while a submission is in flight', async ({ page }) => {
+	page.on('pageerror', (error) => {
+		console.error('pageerror', error);
+	});
+	page.on('console', (message) => {
+		if (message.type() === 'error') {
+			console.error('console', message.text());
+		}
+	});
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: null,
+				solution: null
+			})
+		});
+	});
+
+	let guessRequests = 0;
+	let releaseGuessRequest!: () => void;
+	const guessBlocked = new Promise<void>((resolve) => {
+		releaseGuessRequest = resolve;
+	});
+
+	await page.route('**/api/game/guess', async (route) => {
+		guessRequests += 1;
+		await guessBlocked;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Absent' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Absent' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	const submitPromise = page.keyboard.press('Enter');
+
+	await expect.poll(() => guessRequests).toBe(1);
+	await expect(page.getByTestId('submit-guess')).toBeDisabled();
+	await expect(page.getByTestId('remove-letter')).toBeDisabled();
+	await expect(page.getByTestId('enable-easy-mode')).toBeDisabled();
+
+	await page.keyboard.press('Backspace');
+	await expect(page.getByTestId('board-row-0')).toContainText('CRANE');
+	await page.keyboard.press('Enter');
+	await expect.poll(() => guessRequests).toBe(1);
+
+	releaseGuessRequest();
+	await submitPromise;
 	await expect.poll(() => guessRequests).toBe(1);
 });


### PR DESCRIPTION
Add `|| submitting` to all interactive game button disabled bindings
(Back, letter keys, Enter, and Enable easy mode). Previously a physical
Enter plus on-screen Enter could fire two submit events before the
`submitting` guard became visible, allowing duplicate guess submissions.

Fixes #7