### PR TITLE
Fix average guesses always showing 0 (issue #6)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
@@ -14,6 +14,8 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
         => dbContext.Players
             .Include(p => p.Attempts)
                 .ThenInclude(a => a.DailyPuzzle)
+            .Include(p => p.Attempts)
+                .ThenInclude(a => a.Guesses)
             .FirstOrDefaultAsync(p => p.Id == playerId, cancellationToken);
 
     public Task<Player?> GetPlayerWithAttemptsAndGuesses(Guid playerId, CancellationToken cancellationToken)
@@ -32,6 +34,8 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
         => dbContext.Players
             .Include(p => p.Attempts)
                 .ThenInclude(a => a.DailyPuzzle)
+            .Include(p => p.Attempts)
+                .ThenInclude(a => a.Guesses)
             .ToListAsync(cancellationToken);
 
     public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerRepositoryTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerRepositoryTests.cs
@@ -64,6 +64,133 @@ public class PlayerRepositoryTests
     }
 
     [Fact]
+    public async Task GetPlayersWithAttempts_includes_guesses_so_GuessCount_is_not_zero()
+    {
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseInMemoryDatabase($"players-{Guid.NewGuid()}")
+            .Options;
+
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Guess Count Tester",
+            Email = "guesscount@example.com",
+            PasswordHash = "hash",
+            Attempts = []
+        };
+        var puzzle = new DailyPuzzle
+        {
+            Id = Guid.NewGuid(),
+            PuzzleDate = new DateOnly(2025, 2, 1),
+            Solution = "CRANE"
+        };
+        var attempt = new PlayerPuzzleAttempt
+        {
+            Id = Guid.NewGuid(),
+            Player = player,
+            PlayerId = player.Id,
+            DailyPuzzle = puzzle,
+            DailyPuzzleId = puzzle.Id,
+            Status = AttemptStatus.Solved,
+            PlayedInHardMode = false,
+            CreatedOn = puzzle.PuzzleDate.ToDateTime(TimeOnly.MinValue)
+        };
+        var guess = new GuessAttempt
+        {
+            Id = Guid.NewGuid(),
+            PlayerPuzzleAttempt = attempt,
+            PlayerPuzzleAttemptId = attempt.Id,
+            GuessNumber = 1,
+            GuessWord = "CRANE"
+        };
+        attempt.Guesses.Add(guess);
+        player.Attempts.Add(attempt);
+        puzzle.Attempts.Add(attempt);
+
+        await using (var context = new WordleTrackerSupremeDbContext(options))
+        {
+            context.Add(player);
+            context.Add(puzzle);
+            context.Add(attempt);
+            context.Add(guess);
+            await context.SaveChangesAsync();
+        }
+
+        await using var readContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new PlayerRepository(readContext);
+
+        var players = await repository.GetPlayersWithAttempts(CancellationToken.None);
+
+        players.Should().ContainSingle();
+        var loaded = players.Single();
+        loaded.Attempts.Should().ContainSingle();
+        loaded.Attempts.First().GuessCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetPlayerWithAttempts_includes_guesses_so_GuessCount_is_not_zero()
+    {
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseInMemoryDatabase($"players-{Guid.NewGuid()}")
+            .Options;
+
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Single Player Guess Tester",
+            Email = "singleguesscount@example.com",
+            PasswordHash = "hash",
+            Attempts = []
+        };
+        var puzzle = new DailyPuzzle
+        {
+            Id = Guid.NewGuid(),
+            PuzzleDate = new DateOnly(2025, 2, 2),
+            Solution = "CRANE"
+        };
+        var attempt = new PlayerPuzzleAttempt
+        {
+            Id = Guid.NewGuid(),
+            Player = player,
+            PlayerId = player.Id,
+            DailyPuzzle = puzzle,
+            DailyPuzzleId = puzzle.Id,
+            Status = AttemptStatus.Solved,
+            PlayedInHardMode = false,
+            CreatedOn = puzzle.PuzzleDate.ToDateTime(TimeOnly.MinValue)
+        };
+        var guess = new GuessAttempt
+        {
+            Id = Guid.NewGuid(),
+            PlayerPuzzleAttempt = attempt,
+            PlayerPuzzleAttemptId = attempt.Id,
+            GuessNumber = 1,
+            GuessWord = "CRANE"
+        };
+        attempt.Guesses.Add(guess);
+        player.Attempts.Add(attempt);
+        puzzle.Attempts.Add(attempt);
+
+        await using (var context = new WordleTrackerSupremeDbContext(options))
+        {
+            context.Add(player);
+            context.Add(puzzle);
+            context.Add(attempt);
+            context.Add(guess);
+            await context.SaveChangesAsync();
+        }
+
+        await using var readContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new PlayerRepository(readContext);
+
+        var loaded = await repository.GetPlayerWithAttempts(player.Id, CancellationToken.None);
+
+        loaded.Should().NotBeNull();
+        loaded!.Attempts.Should().ContainSingle();
+        loaded.Attempts.First().GuessCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetPlayerWithAttemptsAndGuesses_includes_guess_feedback()
     {
         var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()


### PR DESCRIPTION
## Summary

- Adds `.ThenInclude(a => a.Guesses)` to `GetPlayerWithAttempts` and `GetPlayersWithAttempts` in `PlayerRepository`
- Adds 2 regression tests to `PlayerRepositoryTests` asserting `GuessCount` equals the actual guess count after the fix

## Root cause

`Attempt.GuessCount` is computed as `Guesses?.Count`. Both repository methods used by the stats and leaderboard endpoints loaded `DailyPuzzle` via `ThenInclude` but not `Guesses`, so the collection was `null` and `GuessCount` returned 0 for every attempt.

`GetPlayerWithAttemptsAndGuesses` (used by the admin panel) already had the correct include and was unaffected.

## Test plan

- [ ] Run `docker-compose --profile tests run --rm tests-backend` — all 46 tests pass
- [ ] Start the stack with seed data and open the leaderboard — average guesses should now show real values instead of 0.00

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)