### PR TITLE
Fix admin validation parity for profile and password updates

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -60,6 +60,10 @@ public class AdminController(IAdminService adminService) : ControllerBase
         {
             return Conflict(new { message = ex.Message });
         }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     [HttpPut("players/{playerId:guid}/password")]
@@ -76,6 +80,10 @@ public class AdminController(IAdminService adminService) : ControllerBase
         catch (KeyNotFoundException)
         {
             return NotFound();
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
         }
     }
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminResetPasswordRequest.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminResetPasswordRequest.cs
@@ -1,3 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+using Wordle.TrackerSupreme.Domain.Validation;
+
 namespace Wordle.TrackerSupreme.Api.Models.Admin;
 
-public record AdminResetPasswordRequest(string Password);
+public record AdminResetPasswordRequest(
+    [Required]
+    [StringLength(PlayerValidationRules.PasswordMaxLength, MinimumLength = PlayerValidationRules.PasswordMinLength)]
+    string Password);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminUpdatePlayerRequest.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminUpdatePlayerRequest.cs
@@ -1,3 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using Wordle.TrackerSupreme.Domain.Validation;
+
 namespace Wordle.TrackerSupreme.Api.Models.Admin;
 
-public record AdminUpdatePlayerRequest(string DisplayName, string Email);
+public record AdminUpdatePlayerRequest(
+    [Required]
+    [StringLength(PlayerValidationRules.DisplayNameMaxLength, MinimumLength = PlayerValidationRules.DisplayNameMinLength)]
+    string DisplayName,
+    [Required]
+    [EmailAddress]
+    [StringLength(PlayerValidationRules.EmailMaxLength)]
+    string Email);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/SignInRequest.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/SignInRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Wordle.TrackerSupreme.Domain.Validation;
 
 namespace Wordle.TrackerSupreme.Api.Models.Auth;
 
@@ -6,10 +7,10 @@ public class SignInRequest
 {
     [Required]
     [EmailAddress]
-    [StringLength(320)]
+    [StringLength(PlayerValidationRules.EmailMaxLength)]
     public string Email { get; set; } = string.Empty;
 
     [Required]
-    [StringLength(100, MinimumLength = 6)]
+    [StringLength(PlayerValidationRules.PasswordMaxLength, MinimumLength = PlayerValidationRules.PasswordMinLength)]
     public string Password { get; set; } = string.Empty;
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/SignUpRequest.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/SignUpRequest.cs
@@ -1,19 +1,20 @@
 using System.ComponentModel.DataAnnotations;
+using Wordle.TrackerSupreme.Domain.Validation;
 
 namespace Wordle.TrackerSupreme.Api.Models.Auth;
 
 public class SignUpRequest
 {
     [Required]
-    [StringLength(200, MinimumLength = 2)]
+    [StringLength(PlayerValidationRules.DisplayNameMaxLength, MinimumLength = PlayerValidationRules.DisplayNameMinLength)]
     public string DisplayName { get; set; } = string.Empty;
 
     [Required]
     [EmailAddress]
-    [StringLength(320)]
+    [StringLength(PlayerValidationRules.EmailMaxLength)]
     public string Email { get; set; } = string.Empty;
 
     [Required]
-    [StringLength(100, MinimumLength = 6)]
+    [StringLength(PlayerValidationRules.PasswordMaxLength, MinimumLength = PlayerValidationRules.PasswordMinLength)]
     public string Password { get; set; } = string.Empty;
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Admin/AdminService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Admin/AdminService.cs
@@ -3,6 +3,7 @@ using Wordle.TrackerSupreme.Application.Services.Game;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Domain.Repositories;
 using Wordle.TrackerSupreme.Domain.Services;
+using Wordle.TrackerSupreme.Domain.Validation;
 
 namespace Wordle.TrackerSupreme.Application.Services.Admin;
 
@@ -36,6 +37,9 @@ public class AdminService(
         var trimmedName = displayName.Trim();
         var trimmedEmail = email.Trim().ToLowerInvariant();
 
+        PlayerValidationRules.EnsureValidDisplayName(trimmedName);
+        PlayerValidationRules.EnsureValidEmail(trimmedEmail);
+
         var nameTaken = await _playerRepository.IsDisplayNameTaken(trimmedName, playerId, cancellationToken);
         if (nameTaken)
         {
@@ -62,6 +66,8 @@ public class AdminService(
         {
             throw new KeyNotFoundException("Player not found.");
         }
+
+        PlayerValidationRules.EnsureValidPassword(newPassword);
 
         player.PasswordHash = _passwordHasher.HashPassword(player, newPassword);
         await _playerRepository.SaveChanges(cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Validation/PlayerValidationRules.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Validation/PlayerValidationRules.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Wordle.TrackerSupreme.Domain.Validation;
+
+public static class PlayerValidationRules
+{
+    public const int DisplayNameMinLength = 2;
+    public const int DisplayNameMaxLength = 200;
+    public const int EmailMaxLength = 320;
+    public const int PasswordMinLength = 6;
+    public const int PasswordMaxLength = 100;
+
+    public static void EnsureValidDisplayName(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            throw new ArgumentException("Display name is required.", nameof(displayName));
+        }
+
+        if (displayName.Length < DisplayNameMinLength || displayName.Length > DisplayNameMaxLength)
+        {
+            throw new ArgumentException(
+                $"Display name must be between {DisplayNameMinLength} and {DisplayNameMaxLength} characters.",
+                nameof(displayName));
+        }
+    }
+
+    public static void EnsureValidEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new ArgumentException("Email is required.", nameof(email));
+        }
+
+        if (email.Length > EmailMaxLength)
+        {
+            throw new ArgumentException($"Email cannot exceed {EmailMaxLength} characters.", nameof(email));
+        }
+
+        var validator = new EmailAddressAttribute();
+        if (!validator.IsValid(email))
+        {
+            throw new ArgumentException("Email must be a valid email address.", nameof(email));
+        }
+    }
+
+    public static void EnsureValidPassword(string password)
+    {
+        if (string.IsNullOrEmpty(password))
+        {
+            throw new ArgumentException("Password is required.", nameof(password));
+        }
+
+        if (password.Length < PasswordMinLength || password.Length > PasswordMaxLength)
+        {
+            throw new ArgumentException(
+                $"Password must be between {PasswordMinLength} and {PasswordMaxLength} characters.",
+                nameof(password));
+        }
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
@@ -124,6 +124,78 @@ public class AdminServiceTests
     }
 
     [Fact]
+    public async Task UpdatePlayerProfile_rejects_blank_display_name()
+    {
+        var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };
+        var validator = new FakeWordValidator(["CRANE"]);
+        var guessService = new GuessEvaluationService(options, validator);
+        var gameRepo = new FakeGameRepository();
+        var passwordHasher = new PasswordHasher<Player>();
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Alpha",
+            Email = "alpha@example.com",
+            PasswordHash = "hash"
+        };
+        var playerRepo = new FakeAdminPlayerRepository([player]);
+        var service = new AdminService(playerRepo, gameRepo, guessService, passwordHasher, options);
+
+        var action = () => service.UpdatePlayerProfile(player.Id, " ", "alpha@example.com", CancellationToken.None);
+
+        await action.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Display name is required.*");
+    }
+
+    [Fact]
+    public async Task UpdatePlayerProfile_rejects_invalid_email()
+    {
+        var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };
+        var validator = new FakeWordValidator(["CRANE"]);
+        var guessService = new GuessEvaluationService(options, validator);
+        var gameRepo = new FakeGameRepository();
+        var passwordHasher = new PasswordHasher<Player>();
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Alpha",
+            Email = "alpha@example.com",
+            PasswordHash = "hash"
+        };
+        var playerRepo = new FakeAdminPlayerRepository([player]);
+        var service = new AdminService(playerRepo, gameRepo, guessService, passwordHasher, options);
+
+        var action = () => service.UpdatePlayerProfile(player.Id, "Alpha", "not-an-email", CancellationToken.None);
+
+        await action.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Email must be a valid email address.*");
+    }
+
+    [Fact]
+    public async Task ResetPassword_rejects_short_password()
+    {
+        var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };
+        var validator = new FakeWordValidator(["CRANE"]);
+        var guessService = new GuessEvaluationService(options, validator);
+        var gameRepo = new FakeGameRepository();
+        var passwordHasher = new PasswordHasher<Player>();
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Alpha",
+            Email = "alpha@example.com",
+            PasswordHash = "hash"
+        };
+        var playerRepo = new FakeAdminPlayerRepository([player]);
+        var service = new AdminService(playerRepo, gameRepo, guessService, passwordHasher, options);
+
+        var action = () => service.ResetPassword(player.Id, "abc", CancellationToken.None);
+
+        await action.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Password must be between 6 and 100 characters.*");
+    }
+
+    [Fact]
     public async Task DeleteAttempt_removes_attempt_and_guesses()
     {
         var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };

--- a/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getAdminPasswordValidationError, getAdminProfileValidationError } from './validation';
+
+describe('admin validation', () => {
+	it('rejects invalid profile values', () => {
+		expect(getAdminProfileValidationError(' ', 'admin@example.com')).toBe(
+			'Display name is required.'
+		);
+		expect(getAdminProfileValidationError('Admin', 'invalid-email')).toBe(
+			'Email must be a valid email address.'
+		);
+	});
+
+	it('accepts valid profile values', () => {
+		expect(getAdminProfileValidationError('Admin Supreme', 'admin@example.com')).toBeNull();
+	});
+
+	it('rejects short passwords', () => {
+		expect(getAdminPasswordValidationError('abc')).toBe(
+			'Password must be between 6 and 100 characters.'
+		);
+	});
+
+	it('accepts valid passwords', () => {
+		expect(getAdminPasswordValidationError('Reset!234')).toBeNull();
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.spec.ts
@@ -13,6 +13,7 @@ describe('admin validation', () => {
 
 	it('accepts valid profile values', () => {
 		expect(getAdminProfileValidationError('Admin Supreme', 'admin@example.com')).toBeNull();
+		expect(getAdminProfileValidationError('Legacy Admin', 'name+legacy@local')).toBeNull();
 	});
 
 	it('rejects short passwords', () => {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.ts
@@ -4,7 +4,7 @@ export const emailMaxLength = 320;
 export const passwordMinLength = 6;
 export const passwordMaxLength = 100;
 
-const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const emailPattern = /^[^\s@]+@[^\s@]+$/;
 
 export function getAdminProfileValidationError(displayName: string, email: string): string | null {
 	const trimmedName = displayName.trim();

--- a/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/admin/validation.ts
@@ -1,0 +1,46 @@
+export const displayNameMinLength = 2;
+export const displayNameMaxLength = 200;
+export const emailMaxLength = 320;
+export const passwordMinLength = 6;
+export const passwordMaxLength = 100;
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function getAdminProfileValidationError(displayName: string, email: string): string | null {
+	const trimmedName = displayName.trim();
+	const trimmedEmail = email.trim();
+
+	if (!trimmedName) {
+		return 'Display name is required.';
+	}
+
+	if (trimmedName.length < displayNameMinLength || trimmedName.length > displayNameMaxLength) {
+		return `Display name must be between ${displayNameMinLength} and ${displayNameMaxLength} characters.`;
+	}
+
+	if (!trimmedEmail) {
+		return 'Email is required.';
+	}
+
+	if (trimmedEmail.length > emailMaxLength) {
+		return `Email cannot exceed ${emailMaxLength} characters.`;
+	}
+
+	if (!emailPattern.test(trimmedEmail)) {
+		return 'Email must be a valid email address.';
+	}
+
+	return null;
+}
+
+export function getAdminPasswordValidationError(password: string): string | null {
+	if (!password) {
+		return 'Password is required.';
+	}
+
+	if (password.length < passwordMinLength || password.length > passwordMaxLength) {
+		return `Password must be between ${passwordMinLength} and ${passwordMaxLength} characters.`;
+	}
+
+	return null;
+}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
@@ -2,11 +2,21 @@
 	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { auth } from '$lib/auth/store';
+	import { ApiError } from '$lib/api-client';
 	import { AdminService } from '$lib/api-client/services/AdminService';
 	import type { AdminPlayerAttemptResponse as ApiAdminPlayerAttemptResponse } from '$lib/api-client/models/AdminPlayerAttemptResponse';
 	import type { AdminPlayerDetailResponse as ApiAdminPlayerDetailResponse } from '$lib/api-client/models/AdminPlayerDetailResponse';
 	import type { AdminPlayerSummaryResponse as ApiAdminPlayerSummaryResponse } from '$lib/api-client/models/AdminPlayerSummaryResponse';
 	import type { GuessResponse } from '$lib/api-client/models/GuessResponse';
+	import {
+		displayNameMaxLength,
+		displayNameMinLength,
+		emailMaxLength,
+		getAdminPasswordValidationError,
+		getAdminProfileValidationError,
+		passwordMaxLength,
+		passwordMinLength
+	} from '$lib/admin/validation';
 
 	const wordLength = 5;
 	const maxGuesses = 6;
@@ -67,6 +77,10 @@
 	let attemptSaving = $state(false);
 	let attemptError = $state<string | null>(null);
 	let deletingAttemptId = $state<string | null>(null);
+	let profileValidationError = $derived(
+		getAdminProfileValidationError(displayNameDraft, emailDraft)
+	);
+	let passwordValidationError = $derived(getAdminPasswordValidationError(passwordDraft));
 
 	$effect(() => {
 		const term = query.trim().toLowerCase();
@@ -88,6 +102,35 @@
 			return value;
 		}
 		return date.toLocaleDateString();
+	}
+
+	function getRequestErrorMessage(err: unknown, fallback: string) {
+		if (err instanceof ApiError) {
+			const body = err.body as
+				| { message?: string; detail?: string; title?: string; errors?: Record<string, string[]> }
+				| undefined;
+
+			if (body?.message) {
+				return body.message;
+			}
+
+			if (body?.detail) {
+				return body.detail;
+			}
+
+			const validationMessages = body?.errors
+				? Object.values(body.errors).flat().filter(Boolean)
+				: [];
+			if (validationMessages.length > 0) {
+				return validationMessages.join(' ');
+			}
+
+			if (body?.title) {
+				return body.title;
+			}
+		}
+
+		return err instanceof Error ? err.message : fallback;
 	}
 
 	async function loadPlayers() {
@@ -164,6 +207,10 @@
 		if (!selectedPlayer) {
 			return;
 		}
+		if (profileValidationError) {
+			profileError = profileValidationError;
+			return;
+		}
 		profileSaving = true;
 		profileError = null;
 		try {
@@ -185,7 +232,7 @@
 					: player
 			);
 		} catch (err) {
-			profileError = err instanceof Error ? err.message : 'Unable to update profile.';
+			profileError = getRequestErrorMessage(err, 'Unable to update profile.');
 		} finally {
 			profileSaving = false;
 		}
@@ -193,6 +240,10 @@
 
 	async function resetPassword() {
 		if (!selectedPlayer) {
+			return;
+		}
+		if (passwordValidationError) {
+			passwordMessage = passwordValidationError;
 			return;
 		}
 		passwordSaving = true;
@@ -205,7 +256,7 @@
 			passwordDraft = '';
 			passwordMessage = 'Password reset successfully.';
 		} catch (err) {
-			passwordMessage = err instanceof Error ? err.message : 'Unable to reset password.';
+			passwordMessage = getRequestErrorMessage(err, 'Unable to reset password.');
 		} finally {
 			passwordSaving = false;
 		}
@@ -227,7 +278,7 @@
 				player.id === detail.id ? { ...player, isAdmin: detail.isAdmin ?? false } : player
 			);
 		} catch (err) {
-			adminError = err instanceof Error ? err.message : 'Unable to update admin status.';
+			adminError = getRequestErrorMessage(err, 'Unable to update admin status.');
 		} finally {
 			adminSaving = false;
 		}
@@ -256,7 +307,7 @@
 			};
 			stopEditing();
 		} catch (err) {
-			attemptError = err instanceof Error ? err.message : 'Unable to update guesses.';
+			attemptError = getRequestErrorMessage(err, 'Unable to update guesses.');
 		} finally {
 			attemptSaving = false;
 		}
@@ -281,7 +332,7 @@
 			);
 			stopEditing();
 		} catch (err) {
-			attemptError = err instanceof Error ? err.message : 'Unable to reset attempt.';
+			attemptError = getRequestErrorMessage(err, 'Unable to reset attempt.');
 		} finally {
 			deletingAttemptId = null;
 		}
@@ -494,6 +545,9 @@
 									<label class="block">
 										<span class="text-xs text-slate-200/70">Display name</span>
 										<input
+											required
+											minlength={displayNameMinLength}
+											maxlength={displayNameMaxLength}
 											class="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none focus:border-emerald-400/60"
 											bind:value={displayNameDraft}
 											data-testid="admin-display-name"
@@ -502,6 +556,9 @@
 									<label class="block">
 										<span class="text-xs text-slate-200/70">Email</span>
 										<input
+											required
+											type="email"
+											maxlength={emailMaxLength}
 											class="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none focus:border-emerald-400/60"
 											bind:value={emailDraft}
 											data-testid="admin-email"
@@ -510,11 +567,14 @@
 									<button
 										class="w-full rounded-full bg-emerald-400 px-4 py-2 text-xs font-semibold tracking-[0.2em] text-slate-900 uppercase transition hover:bg-emerald-300"
 										on:click={saveProfile}
-										disabled={profileSaving}
+										disabled={profileSaving || !!profileValidationError}
 										data-testid="admin-profile-save"
 									>
 										{profileSaving ? 'Saving...' : 'Save profile'}
 									</button>
+									{#if profileValidationError}
+										<div class="text-xs text-amber-200">{profileValidationError}</div>
+									{/if}
 									{#if profileError}
 										<div class="text-xs text-rose-200">{profileError}</div>
 									{/if}
@@ -529,6 +589,8 @@
 										<span class="text-xs text-slate-200/70">Reset password</span>
 										<input
 											type="password"
+											minlength={passwordMinLength}
+											maxlength={passwordMaxLength}
 											class="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none focus:border-emerald-400/60"
 											placeholder="New password"
 											bind:value={passwordDraft}
@@ -538,11 +600,14 @@
 									<button
 										class="w-full rounded-full border border-emerald-300/50 bg-emerald-500/10 px-4 py-2 text-xs font-semibold tracking-[0.2em] text-emerald-100 uppercase transition hover:border-emerald-200"
 										on:click={resetPassword}
-										disabled={passwordSaving || !passwordDraft}
+										disabled={passwordSaving || !!passwordValidationError}
 										data-testid="admin-password-reset"
 									>
 										{passwordSaving ? 'Resetting...' : 'Reset password'}
 									</button>
+									{#if passwordValidationError}
+										<div class="text-xs text-amber-200">{passwordValidationError}</div>
+									{/if}
 									{#if passwordMessage}
 										<div class="text-xs text-slate-200/80">{passwordMessage}</div>
 									{/if}

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/admin.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/admin.spec.ts
@@ -16,6 +16,16 @@ test('admin can manage player profiles and attempts', async ({ page }) => {
 	const attemptCards = page.getByTestId('admin-attempt-card');
 	await expect(attemptCards.first()).toBeVisible();
 
+	await page.getByTestId('admin-email').fill('invalid-email');
+	await expect(page.getByText('Email must be a valid email address.')).toBeVisible();
+	await expect(page.getByTestId('admin-profile-save')).toBeDisabled();
+	await page.getByTestId('admin-email').fill('player1@wordle.supreme');
+	await expect(page.getByTestId('admin-profile-save')).toBeEnabled();
+
+	await page.getByTestId('admin-password').fill('abc');
+	await expect(page.getByText('Password must be between 6 and 100 characters.')).toBeVisible();
+	await expect(page.getByTestId('admin-password-reset')).toBeDisabled();
+
 	await page.getByTestId('admin-password').fill('Reset!234');
 	await page.getByTestId('admin-password-reset').click();
 	await expect(page.getByText('Password reset successfully.')).toBeVisible();


### PR DESCRIPTION
## Summary
- enforce the same display name, email, and password rules on admin update/reset endpoints as the public auth flow
- add defense-in-depth validation inside `AdminService` and return clean 400 responses instead of persisting invalid data
- add admin-page client-side validation plus regression coverage in backend, frontend, and full E2E tests

## Verification
- `sudo docker-compose -p wts-issue14-backend-rerun --profile tests run --rm tests-backend`
- `sudo docker-compose -p wts-issue14-frontend --profile tests run --rm tests-frontend`
- `npm run lint` in `src/Wordle.TrackerSupreme.Web`
- full E2E suite: `npm run e2e` with `E2E_BASE_URL=http://localhost:3000` after reseeding the local stack

Closes #14
