### PR TITLE
Fix auth endpoint rate limiting

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Auth/AuthRateLimiting.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Auth/AuthRateLimiting.cs
@@ -1,0 +1,9 @@
+namespace Wordle.TrackerSupreme.Api.Auth;
+
+public static class AuthRateLimiting
+{
+    public const string PolicyName = "auth";
+    public const string TooManyAttemptsMessage = "Too many authentication attempts. Please try again in a minute.";
+    public const int PermitLimit = 25;
+    public static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Wordle.TrackerSupreme.Api.Auth;
@@ -18,6 +19,7 @@ public class AuthController(
     PasswordHasher<Player> passwordHasher)
     : ControllerBase
 {
+    [EnableRateLimiting(AuthRateLimiting.PolicyName)]
     [HttpPost("signup")]
     public async Task<ActionResult<AuthResponse>> SignUp([FromBody] SignUpRequest request)
     {
@@ -54,6 +56,7 @@ public class AuthController(
         return Ok(new AuthResponse(MapPlayer(player), token));
     }
 
+    [EnableRateLimiting(AuthRateLimiting.PolicyName)]
     [HttpPost("signin")]
     public async Task<ActionResult<AuthResponse>> SignIn([FromBody] SignInRequest request)
     {

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -2,9 +2,11 @@ using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using System.Threading.RateLimiting;
 using Wordle.TrackerSupreme.Api.Auth;
 using Wordle.TrackerSupreme.Application.Services.Admin;
 using Wordle.TrackerSupreme.Application.Services.Game;
@@ -94,6 +96,31 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ClockSkew = TimeSpan.FromMinutes(2)
         };
     });
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        if (!context.HttpContext.Response.HasStarted)
+        {
+            context.HttpContext.Response.ContentType = "application/json";
+            await context.HttpContext.Response.WriteAsJsonAsync(
+                new { message = AuthRateLimiting.TooManyAttemptsMessage },
+                cancellationToken);
+        }
+    };
+
+    options.AddPolicy(AuthRateLimiting.PolicyName, httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = AuthRateLimiting.PermitLimit,
+                Window = AuthRateLimiting.Window,
+                QueueLimit = 0,
+                AutoReplenishment = true
+            }));
+});
 
 builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection(JwtSettings.SectionName));
 builder.Services.Configure<GameOptions>(builder.Configuration.GetSection(GameOptions.SectionName));
@@ -148,6 +175,7 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseCors();
+app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -173,3 +201,5 @@ app.MapGet("/health/ready", async (WordleTrackerSupremeDbContext dbContext, Canc
 app.MapControllers();
 
 app.Run();
+
+public partial class Program;

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
@@ -96,6 +97,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ClockSkew = TimeSpan.FromMinutes(2)
         };
     });
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -174,6 +181,7 @@ if (!app.Environment.IsDevelopment())
     app.UseHttpsRedirection();
 }
 
+app.UseForwardedHeaders();
 app.UseCors();
 app.UseRateLimiter();
 app.UseAuthentication();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthRateLimitingTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthRateLimitingTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Wordle.TrackerSupreme.Api.Auth;
+using Wordle.TrackerSupreme.Api.Controllers;
+using Wordle.TrackerSupreme.Domain.Models;
+using Wordle.TrackerSupreme.Infrastructure.Database;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class AuthRateLimitingTests
+{
+    private const string AdminEmail = "admin@wordle.supreme";
+    private const string AdminCredential = "dev-password";
+    private const string InvalidCredential = "wrong-password";
+    private const string ValidCredential = "Supreme!234";
+
+    [Fact]
+    public async Task SignIn_returns_too_many_requests_after_limit_is_exceeded()
+    {
+        await using var factory = new AuthRateLimitingFactory();
+        using var client = factory.CreateClient();
+        var payload = new { email = AdminEmail, password = InvalidCredential };
+
+        for (var attempt = 0; attempt < AuthRateLimiting.PermitLimit; attempt++)
+        {
+            var response = await client.PostAsJsonAsync("/api/auth/signin", payload);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        var limited = await client.PostAsJsonAsync("/api/auth/signin", payload);
+
+        limited.StatusCode.Should().Be((HttpStatusCode)429);
+        var body = await limited.Content.ReadFromJsonAsync<MessageResponse>();
+        body.Should().NotBeNull();
+        body!.Message.Should().Be(AuthRateLimiting.TooManyAttemptsMessage);
+    }
+
+    [Fact]
+    public async Task SignUp_returns_too_many_requests_after_limit_is_exceeded()
+    {
+        await using var factory = new AuthRateLimitingFactory();
+        using var client = factory.CreateClient();
+
+        for (var attempt = 0; attempt < AuthRateLimiting.PermitLimit; attempt++)
+        {
+            var response = await client.PostAsJsonAsync("/api/auth/signup", new
+            {
+                displayName = $"RateLimitUser{attempt}",
+                email = $"ratelimit{attempt}@example.com",
+                password = ValidCredential
+            });
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        var limited = await client.PostAsJsonAsync("/api/auth/signup", new
+        {
+            displayName = "RateLimitUserFinal",
+            email = "ratelimit-final@example.com",
+            password = ValidCredential
+        });
+
+        limited.StatusCode.Should().Be((HttpStatusCode)429);
+        var body = await limited.Content.ReadFromJsonAsync<MessageResponse>();
+        body.Should().NotBeNull();
+        body!.Message.Should().Be(AuthRateLimiting.TooManyAttemptsMessage);
+    }
+
+    private sealed class AuthRateLimitingFactory : WebApplicationFactory<AuthController>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [$"{JwtSettings.SectionName}:Secret"] = "12345678901234567890123456789012",
+                    [$"{JwtSettings.SectionName}:Issuer"] = "test-issuer",
+                    [$"{JwtSettings.SectionName}:Audience"] = "test-audience"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<DbContextOptions<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<WordleTrackerSupremeDbContext>();
+
+                services.AddDbContext<WordleTrackerSupremeDbContext>(options =>
+                    options.UseInMemoryDatabase($"auth-rate-limit-{Guid.NewGuid()}"));
+
+                using var scope = services.BuildServiceProvider().CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<WordleTrackerSupremeDbContext>();
+                dbContext.Database.EnsureCreated();
+
+                var admin = new Player
+                {
+                    Id = Guid.NewGuid(),
+                    DisplayName = "AdminSupreme",
+                    Email = AdminEmail,
+                    PasswordHash = string.Empty,
+                    IsAdmin = true
+                };
+
+                var passwordHasher = scope.ServiceProvider.GetRequiredService<PasswordHasher<Player>>();
+                admin.PasswordHash = passwordHasher.HashPassword(admin, AdminCredential);
+                dbContext.Players.Add(admin);
+                dbContext.SaveChanges();
+            });
+        }
+    }
+
+    private sealed record MessageResponse(string Message);
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthRateLimitingTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthRateLimitingTests.cs
@@ -46,6 +46,28 @@ public class AuthRateLimitingTests
     }
 
     [Fact]
+    public async Task SignIn_uses_forwarded_client_ip_for_rate_limit_partitioning()
+    {
+        await using var factory = new AuthRateLimitingFactory();
+        using var firstClient = factory.CreateClient();
+        using var secondClient = factory.CreateClient();
+        var payload = new { email = AdminEmail, password = InvalidCredential };
+
+        firstClient.DefaultRequestHeaders.Add("X-Forwarded-For", "198.51.100.10");
+        secondClient.DefaultRequestHeaders.Add("X-Forwarded-For", "198.51.100.11");
+
+        for (var attempt = 0; attempt < AuthRateLimiting.PermitLimit; attempt++)
+        {
+            var response = await firstClient.PostAsJsonAsync("/api/auth/signin", payload);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        var secondClientResponse = await secondClient.PostAsJsonAsync("/api/auth/signin", payload);
+
+        secondClientResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task SignUp_returns_too_many_requests_after_limit_is_exceeded()
     {
         await using var factory = new AuthRateLimitingFactory();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api/errors.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api/errors.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '$lib/api-client';
+import { getApiErrorMessage } from './errors';
+
+describe('getApiErrorMessage', () => {
+	it('prefers explicit API message bodies', () => {
+		const error = new ApiError(
+			{ method: 'POST', url: '/test' },
+			{
+				url: '/test',
+				ok: false,
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: { message: 'Slow down.' }
+			},
+			'Too Many Requests'
+		);
+
+		expect(getApiErrorMessage(error, 'Fallback')).toBe('Slow down.');
+	});
+
+	it('falls back to the error message when no API body message exists', () => {
+		expect(getApiErrorMessage(new Error('Boom'), 'Fallback')).toBe('Boom');
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api/errors.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api/errors.ts
@@ -1,0 +1,30 @@
+import { ApiError } from '$lib/api-client';
+
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+	if (error instanceof ApiError) {
+		const body = error.body as
+			| { message?: string; detail?: string; title?: string; errors?: Record<string, string[]> }
+			| undefined;
+
+		if (body?.message) {
+			return body.message;
+		}
+
+		if (body?.detail) {
+			return body.detail;
+		}
+
+		const validationMessages = body?.errors
+			? Object.values(body.errors).flat().filter(Boolean)
+			: [];
+		if (validationMessages.length > 0) {
+			return validationMessages.join(' ');
+		}
+
+		if (body?.title) {
+			return body.title;
+		}
+	}
+
+	return error instanceof Error ? error.message : fallback;
+}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/signin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/signin/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { getApiErrorMessage } from '$lib/api/errors';
 	import { auth, signIn } from '$lib/auth/store';
 	import { onMount } from 'svelte';
 
@@ -32,7 +33,7 @@
 			await signIn(email, password);
 			goto(resolve('/'));
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Unable to sign in.';
+			error = getApiErrorMessage(err, 'Unable to sign in.');
 		} finally {
 			loading = false;
 		}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/signup/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/signup/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { getApiErrorMessage } from '$lib/api/errors';
 	import { auth, signUp } from '$lib/auth/store';
 	import { onMount } from 'svelte';
 
@@ -35,7 +36,7 @@
 			await signUp(displayName, email, password);
 			goto(resolve('/'));
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Unable to sign up.';
+			error = getApiErrorMessage(err, 'Unable to sign up.');
 		} finally {
 			loading = false;
 		}

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/zz-auth-rate-limit.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/zz-auth-rate-limit.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('sign-in shows a clear message after too many failed attempts', async ({ page }) => {
+	await page.goto('/signin');
+	await page.getByLabel('Email').fill('admin@wordle.supreme');
+	const message = page.getByText('Too many authentication attempts. Please try again in a minute.');
+
+	for (let attempt = 0; attempt < 40; attempt += 1) {
+		await page.getByLabel('Password').fill('wrong-password');
+		await page.getByRole('button', { name: 'Sign in' }).click();
+
+		if (await message.isVisible()) {
+			break;
+		}
+	}
+
+	await expect(message).toBeVisible();
+	await expect(page).toHaveURL(/\/signin$/);
+});


### PR DESCRIPTION
Closes #10

## Summary
- add rate limiting to auth sign-in and sign-up endpoints with a clear 429 JSON message
- surface API-provided auth errors in the sign-in and sign-up forms
- cover the behavior with backend integration tests, frontend unit tests, and full E2E coverage

## Verification
- sudo docker-compose run --rm tests-backend -lc "dotnet test Wordle.TrackerSupreme.sln"
- npm test -- --run
- npm run lint
- E2E_BASE_URL=http://localhost:3000 E2E_ARTIFACT_DIR=/home/vboxuser/code/codex_repos/Wordle.TrackerSupreme/artifacts/issue-10-e2e npm run e2e