### PR TITLE
Expire JWT sessions and handle 401 redirects

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -89,6 +89,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret)),
             ValidateIssuer = true,
             ValidateAudience = true,
+            ValidateLifetime = true,
+            RequireExpirationTime = true,
             ValidIssuer = issuer,
             ValidAudience = audience,
             ClockSkew = TimeSpan.FromMinutes(2)
@@ -173,3 +175,5 @@ app.MapGet("/health/ready", async (WordleTrackerSupremeDbContext dbContext, Canc
 app.MapControllers();
 
 app.Run();
+
+public partial class Program;

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/JwtAuthenticationTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/JwtAuthenticationTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Tokens;
+using Wordle.TrackerSupreme.Api.Auth;
+using Wordle.TrackerSupreme.Api.Controllers;
+using Wordle.TrackerSupreme.Domain.Models;
+using Wordle.TrackerSupreme.Infrastructure.Database;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class JwtAuthenticationTests
+{
+    private const string AdminEmail = "admin@wordle.supreme";
+    private const string AdminCredential = "dev-password";
+    private const string JwtSecret = "12345678901234567890123456789012";
+    private const string JwtIssuer = "test-issuer";
+    private const string JwtAudience = "test-audience";
+
+    [Fact]
+    public async Task GetCurrentPlayer_rejects_expired_tokens()
+    {
+        await using var factory = new AuthFactory(expiryMinutes: -10);
+        using var client = factory.CreateClient();
+        var token = CreateExpiredToken(factory.SeededAdmin);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private sealed class AuthFactory(int expiryMinutes) : WebApplicationFactory<AuthController>
+    {
+        public Player SeededAdmin { get; private set; } = null!;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [$"{JwtSettings.SectionName}:Secret"] = JwtSecret,
+                    [$"{JwtSettings.SectionName}:Issuer"] = JwtIssuer,
+                    [$"{JwtSettings.SectionName}:Audience"] = JwtAudience,
+                    [$"{JwtSettings.SectionName}:ExpiryMinutes"] = expiryMinutes.ToString()
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<DbContextOptions<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<WordleTrackerSupremeDbContext>();
+
+                services.AddDbContext<WordleTrackerSupremeDbContext>(options =>
+                    options.UseInMemoryDatabase($"jwt-auth-{Guid.NewGuid()}"));
+
+                using var scope = services.BuildServiceProvider().CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<WordleTrackerSupremeDbContext>();
+                dbContext.Database.EnsureCreated();
+
+                var admin = new Player
+                {
+                    Id = Guid.NewGuid(),
+                    DisplayName = "AdminSupreme",
+                    Email = AdminEmail,
+                    PasswordHash = string.Empty,
+                    IsAdmin = true
+                };
+
+                var passwordHasher = scope.ServiceProvider.GetRequiredService<PasswordHasher<Player>>();
+                admin.PasswordHash = passwordHasher.HashPassword(admin, AdminCredential);
+                SeededAdmin = admin;
+                dbContext.Players.Add(admin);
+                dbContext.SaveChanges();
+            });
+        }
+    }
+
+    private static string CreateExpiredToken(Player player)
+    {
+        var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
+        var now = DateTime.UtcNow;
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, player.Id.ToString()),
+                new Claim(JwtRegisteredClaimNames.UniqueName, player.DisplayName),
+                new Claim("playerId", player.Id.ToString()),
+                new Claim("isAdmin", player.IsAdmin ? "true" : "false")
+            },
+            notBefore: now.AddHours(-2),
+            expires: now.AddHours(-1),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const notifyUnauthorizedResponse = vi.fn();
+
+vi.mock('$lib/api', () => ({
+	notifyUnauthorizedResponse
+}));
+
+const { request } = await import('./request');
+
+describe('generated api request', () => {
+	beforeEach(() => {
+		notifyUnauthorizedResponse.mockReset();
+		vi.restoreAllMocks();
+	});
+
+	it('notifies the auth layer when an authenticated request returns 401', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			headers: new Headers({ 'Content-Type': 'application/json' }),
+			json: () => Promise.resolve({ message: 'Unauthorized' })
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await expect(
+			request(
+				{
+					BASE: 'http://api.test',
+					VERSION: '1',
+					WITH_CREDENTIALS: false,
+					CREDENTIALS: 'include',
+					TOKEN: 'abc123'
+				},
+				{
+					method: 'GET',
+					url: '/secure'
+				}
+			)
+		).rejects.toThrowError('Unauthorized');
+
+		expect(notifyUnauthorizedResponse).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import { notifyUnauthorizedResponse } from '$lib/api';
 import { ApiError } from './ApiError';
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
@@ -329,6 +330,8 @@ export const request = <T>(
 					statusText: response.statusText,
 					body: responseHeader ?? responseBody
 				};
+
+				notifyUnauthorizedResponse(response.status === 401 && headers.has('Authorization'));
 
 				catchErrorCodes(options, result);
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 import { OpenAPI } from '$lib/api-client';
 
 let baseConfigured = false;
+let unauthorizedHandler: (() => void) | null = null;
 
 const fallbackApiBase = (() => {
 	if (typeof window === 'undefined') {
@@ -32,4 +33,16 @@ export function configureApiClient(token: string | null) {
 export function getApiBase() {
 	ensureBaseConfigured();
 	return OpenAPI.BASE;
+}
+
+export function registerUnauthorizedHandler(handler: (() => void) | null) {
+	unauthorizedHandler = handler;
+}
+
+export function notifyUnauthorizedResponse(hasAuthorization: boolean) {
+	if (!hasAuthorization) {
+		return;
+	}
+
+	unauthorizedHandler?.();
 }

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
@@ -90,6 +90,17 @@ describe('auth store', () => {
 		expect(get(auth).token).toBeNull();
 	});
 
+	it('bootstrapAuth preserves a pending expiry error for the redirected sign-in page', async () => {
+		localStorage.setItem('wts_auth_token', 'expired');
+		sessionStorage.setItem('wts_auth_error', 'Session expired. Please sign in again.');
+		mockAuthService.getApiAuthMe.mockRejectedValue(new Error('expired'));
+
+		await bootstrapAuth();
+
+		expect(get(auth).error).toBe('Session expired. Please sign in again.');
+		expect(sessionStorage.getItem('wts_auth_error')).toBe('Session expired. Please sign in again.');
+	});
+
 	it('bootstrapAuth maps admin flag', async () => {
 		localStorage.setItem('wts_auth_token', 'keep');
 		mockAuthService.getApiAuthMe.mockResolvedValue({

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
@@ -6,13 +6,17 @@ const mockAuthService = {
 	postApiAuthSignup: vi.fn(),
 	getApiAuthMe: vi.fn()
 };
+let unauthorizedHandler: (() => void) | null = null;
 
 vi.mock('$lib/api-client/services/AuthService', () => ({
 	AuthService: mockAuthService
 }));
 
 vi.mock('$lib/api', () => ({
-	configureApiClient: vi.fn()
+	configureApiClient: vi.fn(),
+	registerUnauthorizedHandler: vi.fn((handler: (() => void) | null) => {
+		unauthorizedHandler = handler;
+	})
 }));
 
 const { auth, signIn, signUp, signOut, bootstrapAuth } = await import('./store');
@@ -20,7 +24,7 @@ const { auth, signIn, signUp, signOut, bootstrapAuth } = await import('./store')
 describe('auth store', () => {
 	beforeEach(() => {
 		localStorage.clear();
-		vi.resetAllMocks();
+		vi.clearAllMocks();
 		vi.spyOn(console, 'error').mockImplementation(() => {});
 		auth.set({ user: null, token: null, ready: true });
 	});
@@ -99,5 +103,27 @@ describe('auth store', () => {
 		await bootstrapAuth();
 
 		expect(get(auth).user?.isAdmin).toBe(true);
+	});
+
+	it('unauthorized handler clears auth state and redirects to sign-in', () => {
+		localStorage.setItem('wts_auth_token', 'keepme');
+		auth.set({
+			user: {
+				id: '1',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '',
+				isAdmin: false
+			},
+			token: 'keepme',
+			ready: true,
+			error: null
+		});
+
+		unauthorizedHandler?.();
+
+		expect(localStorage.getItem('wts_auth_token')).toBeNull();
+		expect(get(auth).user).toBeNull();
+		expect(get(auth).error).toBe('Session expired. Please sign in again.');
 	});
 });

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
@@ -1,11 +1,12 @@
 import { AuthService } from '$lib/api-client/services/AuthService';
-import { configureApiClient } from '$lib/api';
+import { configureApiClient, registerUnauthorizedHandler } from '$lib/api';
 import { writable } from 'svelte/store';
 import type { AuthResponse as ApiAuthResponse } from '$lib/api-client/models/AuthResponse';
 import type { PlayerResponse as ApiPlayerResponse } from '$lib/api-client/models/PlayerResponse';
 import type { AuthState, Player } from './types';
 
 const TOKEN_STORAGE_KEY = 'wts_auth_token';
+const PENDING_AUTH_ERROR_KEY = 'wts_auth_error';
 
 function loadStoredToken(): string | null {
 	if (typeof localStorage === 'undefined') {
@@ -25,25 +26,86 @@ function persistToken(token: string | null) {
 	}
 }
 
+function persistPendingAuthError(error: string | null) {
+	if (typeof sessionStorage === 'undefined') {
+		return;
+	}
+
+	if (error) {
+		sessionStorage.setItem(PENDING_AUTH_ERROR_KEY, error);
+	} else {
+		sessionStorage.removeItem(PENDING_AUTH_ERROR_KEY);
+	}
+}
+
+function consumePendingAuthError(): string | null {
+	if (typeof sessionStorage === 'undefined') {
+		return null;
+	}
+
+	const error = sessionStorage.getItem(PENDING_AUTH_ERROR_KEY);
+	if (error) {
+		sessionStorage.removeItem(PENDING_AUTH_ERROR_KEY);
+	}
+
+	return error;
+}
+
 const initialToken = loadStoredToken();
 
 export const auth = writable<AuthState>({
 	user: null,
 	token: initialToken,
-	ready: false
+	ready: false,
+	error: null
 });
 
 configureApiClient(initialToken);
 
-function setAuthenticated(result: ApiAuthResponse) {
-	persistToken(result.token);
-	configureApiClient(result.token);
+function setAuthState(
+	token: string | null,
+	user: Player | null,
+	error: string | null,
+	clearPendingAuthError = true
+) {
+	persistToken(token);
+	configureApiClient(token);
+	if (clearPendingAuthError) {
+		persistPendingAuthError(null);
+	}
 	auth.set({
-		user: mapPlayer(result.player),
-		token: result.token,
+		user,
+		token,
 		ready: true,
-		error: null
+		error
 	});
+}
+
+function redirectToSignIn() {
+	if (typeof window === 'undefined') {
+		return;
+	}
+
+	const signInPath = '/signin';
+	if (window.location.pathname === signInPath) {
+		return;
+	}
+
+	window.location.assign(signInPath);
+}
+
+export function expireSession(message = 'Session expired. Please sign in again.') {
+	persistPendingAuthError(message);
+	setAuthState(null, null, message, false);
+	redirectToSignIn();
+}
+
+registerUnauthorizedHandler(() => {
+	expireSession();
+});
+
+function setAuthenticated(result: ApiAuthResponse) {
+	setAuthState(result.token ?? null, mapPlayer(result.player), null);
 }
 
 function mapPlayer(player: ApiPlayerResponse): Player {
@@ -59,7 +121,7 @@ function mapPlayer(player: ApiPlayerResponse): Player {
 export async function bootstrapAuth() {
 	const token = loadStoredToken();
 	if (!token) {
-		auth.set({ user: null, token: null, ready: true });
+		auth.set({ user: null, token: null, ready: true, error: consumePendingAuthError() });
 		return;
 	}
 
@@ -70,8 +132,7 @@ export async function bootstrapAuth() {
 		auth.set({ user: mapPlayer(player), token, ready: true, error: null });
 	} catch (error) {
 		console.error('Auth bootstrap failed', error);
-		persistToken(null);
-		auth.set({ user: null, token: null, ready: true, error: 'Session expired. Please sign in.' });
+		setAuthState(null, null, consumePendingAuthError() ?? 'Session expired. Please sign in.');
 	}
 }
 
@@ -90,7 +151,5 @@ export async function signUp(displayName: string, email: string, password: strin
 }
 
 export function signOut() {
-	persistToken(null);
-	configureApiClient(null);
-	auth.set({ user: null, token: null, ready: true, error: null });
+	setAuthState(null, null, null);
 }

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
@@ -51,6 +51,14 @@ function consumePendingAuthError(): string | null {
 	return error;
 }
 
+function loadPendingAuthError(): string | null {
+	if (typeof sessionStorage === 'undefined') {
+		return null;
+	}
+
+	return sessionStorage.getItem(PENDING_AUTH_ERROR_KEY);
+}
+
 const initialToken = loadStoredToken();
 
 export const auth = writable<AuthState>({
@@ -132,7 +140,13 @@ export async function bootstrapAuth() {
 		auth.set({ user: mapPlayer(player), token, ready: true, error: null });
 	} catch (error) {
 		console.error('Auth bootstrap failed', error);
-		setAuthState(null, null, consumePendingAuthError() ?? 'Session expired. Please sign in.');
+		const pendingAuthError = loadPendingAuthError();
+		setAuthState(
+			null,
+			null,
+			pendingAuthError ?? 'Session expired. Please sign in.',
+			pendingAuthError === null
+		);
 	}
 }
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const notifyUnauthorizedResponse = vi.fn();
+
 vi.mock('$lib/api', () => ({
-	getApiBase: () => 'http://api.test'
+	getApiBase: () => 'http://api.test',
+	notifyUnauthorizedResponse
 }));
 
 const openApiMock = { TOKEN: undefined as string | undefined };
@@ -15,6 +18,7 @@ const { enableEasyMode, fetchGameState, submitGuess } = await import('./api');
 describe('api helpers', () => {
 	beforeEach(() => {
 		openApiMock.TOKEN = undefined;
+		notifyUnauthorizedResponse.mockReset();
 		vi.restoreAllMocks();
 	});
 
@@ -45,6 +49,21 @@ describe('api helpers', () => {
 		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
 
 		await expect(submitGuess('crane')).rejects.toThrowError('Nope');
+	});
+
+	it('notifies the auth layer when an authenticated request returns 401', async () => {
+		openApiMock.TOKEN = 'abc123';
+		const mockResponse = {
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			text: () => Promise.resolve(JSON.stringify({ message: 'Unauthorized' }))
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await expect(fetchGameState()).rejects.toThrowError('Unauthorized');
+		expect(notifyUnauthorizedResponse).toHaveBeenCalledWith(true);
 	});
 
 	it('posts to easy mode endpoint', async () => {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
@@ -1,4 +1,4 @@
-import { getApiBase } from '$lib/api';
+import { getApiBase, notifyUnauthorizedResponse } from '$lib/api';
 import { OpenAPI } from '$lib/api-client';
 import { StatsService } from '$lib/api-client/services/StatsService';
 import type { GameStateResponse, PlayerStatsResponse, SolutionsResponse } from './types';
@@ -16,6 +16,8 @@ async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 		...init,
 		headers
 	});
+
+	notifyUnauthorizedResponse(response.status === 401 && headers.has('Authorization'));
 
 	if (!response.ok) {
 		let message = 'Request failed';

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/session-expiry.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/session-expiry.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { signUp } from './helpers';
+
+test('redirects to sign-in when an authenticated game request returns 401', async ({ page }) => {
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E Session ${nonce}`,
+		email: `e2e.session.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 401,
+			contentType: 'application/json',
+			body: JSON.stringify({ message: 'Unauthorized' })
+		});
+	});
+
+	await page.goto('/');
+
+	await expect(page).toHaveURL(/\/signin$/);
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/session-expiry.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/session-expiry.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test('redirects to sign-in when an authenticated game request returns 401', async ({ page }) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 401,
+			contentType: 'application/json',
+			body: JSON.stringify({ message: 'Unauthorized' })
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+	await expect(page).toHaveURL(/\/signin$/);
+});


### PR DESCRIPTION
Closes #46

## Summary
- enforce JWT expiration in the API so expired bearer tokens are rejected
- clear local auth state and redirect users back to sign-in when authenticated requests start returning 401
- add backend, unit, UI, and E2E coverage for session expiry behavior

## Verification
- sudo docker-compose run --rm tests-backend -lc "dotnet test Wordle.TrackerSupreme.sln"
- npm test -- --run
- npm run lint
- npx playwright test tests/ui/session-expiry.spec.ts --project=chromium
- E2E_BASE_URL=http://localhost:3000 E2E_ARTIFACT_DIR=/home/vboxuser/code/codex_repos/Wordle.TrackerSupreme/artifacts/issue-46-e2e npm run e2e