### PR TITLE
[codex] Move auth sessions into HttpOnly cookies

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Auth/AuthCookie.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Auth/AuthCookie.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Wordle.TrackerSupreme.Api.Auth;
+
+public static class AuthCookie
+{
+    public const string CookieName = "wts_auth";
+
+    public static CookieOptions BuildOptions(bool secure)
+        => new()
+        {
+            HttpOnly = true,
+            IsEssential = true,
+            SameSite = SameSiteMode.Lax,
+            Secure = secure,
+            Path = "/",
+            Expires = DateTimeOffset.UtcNow.AddDays(1)
+        };
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -16,7 +16,8 @@ namespace Wordle.TrackerSupreme.Api.Controllers;
 public class AuthController(
     WordleTrackerSupremeDbContext dbContext,
     JwtTokenService tokenService,
-    PasswordHasher<Player> passwordHasher)
+    PasswordHasher<Player> passwordHasher,
+    IWebHostEnvironment environment)
     : ControllerBase
 {
     [EnableRateLimiting(AuthRateLimiting.PolicyName)]
@@ -52,8 +53,8 @@ public class AuthController(
         dbContext.Players.Add(player);
         await dbContext.SaveChangesAsync();
 
-        var token = tokenService.CreateToken(player);
-        return Ok(new AuthResponse(MapPlayer(player), token));
+        SignInPlayer(player);
+        return Ok(new AuthResponse(MapPlayer(player), null));
     }
 
     [EnableRateLimiting(AuthRateLimiting.PolicyName)]
@@ -75,8 +76,15 @@ public class AuthController(
             return Unauthorized(new { message = "Invalid credentials." });
         }
 
-        var token = tokenService.CreateToken(player);
-        return Ok(new AuthResponse(MapPlayer(player), token));
+        SignInPlayer(player);
+        return Ok(new AuthResponse(MapPlayer(player), null));
+    }
+
+    [HttpPost("signout")]
+    public IActionResult SignOutCurrentSession()
+    {
+        Response.Cookies.Delete(AuthCookie.CookieName, AuthCookie.BuildOptions(!environment.IsDevelopment()));
+        return NoContent();
     }
 
     [Authorize]
@@ -100,4 +108,13 @@ public class AuthController(
 
     private static PlayerResponse MapPlayer(Player player)
         => new(player.Id, player.DisplayName, player.Email, player.CreatedOn, player.IsAdmin);
+
+    private void SignInPlayer(Player player)
+    {
+        var token = tokenService.CreateToken(player);
+        Response.Cookies.Append(
+            AuthCookie.CookieName,
+            token,
+            AuthCookie.BuildOptions(!environment.IsDevelopment()));
+    }
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/AuthResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Auth/AuthResponse.cs
@@ -1,3 +1,3 @@
 namespace Wordle.TrackerSupreme.Api.Models.Auth;
 
-public record AuthResponse(PlayerResponse Player, string Token);
+public record AuthResponse(PlayerResponse Player, string? Token);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -98,6 +98,23 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidAudience = audience,
             ClockSkew = TimeSpan.FromMinutes(2)
         };
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                if (!string.IsNullOrWhiteSpace(context.Token))
+                {
+                    return Task.CompletedTask;
+                }
+
+                if (context.Request.Cookies.TryGetValue(AuthCookie.CookieName, out var cookieToken))
+                {
+                    context.Token = cookieToken;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
     });
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
@@ -166,6 +183,7 @@ builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
         policy.WithOrigins(allowedOrigins)
+            .AllowCredentials()
             .AllowAnyHeader()
             .AllowAnyMethod());
 });

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthCookieTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthCookieTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Wordle.TrackerSupreme.Api.Auth;
+using Wordle.TrackerSupreme.Api.Controllers;
+using Wordle.TrackerSupreme.Api.Models.Auth;
+using Wordle.TrackerSupreme.Infrastructure.Database;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class AuthCookieTests
+{
+    private const string ValidCredential = "Supreme!234";
+
+    [Fact]
+    public async Task SignUp_sets_http_only_auth_cookie_and_does_not_return_a_browser_token()
+    {
+        await using var factory = new AuthCookieFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            HandleCookies = true
+        });
+        var nonce = Guid.NewGuid().ToString("N");
+
+        var response = await client.PostAsJsonAsync("/api/auth/signup", new
+        {
+            displayName = $"CookieUser{nonce[..8]}",
+            email = $"cookie.{nonce}@example.com",
+            password = ValidCredential
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.TryGetValues("Set-Cookie", out var setCookieValues).Should().BeTrue();
+        setCookieValues.Should().NotBeNull();
+        setCookieValues!.Should().Contain(value =>
+            value.Contains($"{AuthCookie.CookieName}=")
+            && value.Contains("httponly", StringComparison.OrdinalIgnoreCase));
+
+        var body = await response.Content.ReadFromJsonAsync<AuthResponse>();
+        body.Should().NotBeNull();
+        body!.Token.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SignOut_returns_a_clearing_cookie_for_the_auth_session()
+    {
+        await using var factory = new AuthCookieFactory();
+        using var client = factory.CreateClient();
+        var nonce = Guid.NewGuid().ToString("N");
+
+        var signUp = await client.PostAsJsonAsync("/api/auth/signup", new
+        {
+            displayName = $"CookieUser{nonce[..8]}",
+            email = $"cookie.{nonce}@example.com",
+            password = ValidCredential
+        });
+        signUp.EnsureSuccessStatusCode();
+        var authCookie = signUp.Headers.GetValues("Set-Cookie")
+            .Single(value => value.StartsWith($"{AuthCookie.CookieName}=", StringComparison.Ordinal));
+        var cookieHeader = authCookie.Split(';', 2)[0];
+
+        using var signOutRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/signout");
+        signOutRequest.Headers.Add("Cookie", cookieHeader);
+        var signOut = await client.SendAsync(signOutRequest);
+        signOut.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        signOut.Headers.TryGetValues("Set-Cookie", out var signOutCookies).Should().BeTrue();
+        signOutCookies.Should().NotBeNull();
+        signOutCookies!.Should().Contain(value =>
+            value.Contains($"{AuthCookie.CookieName}=")
+            && value.Contains("expires=", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class AuthCookieFactory : WebApplicationFactory<AuthController>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [$"{JwtSettings.SectionName}:Secret"] = "12345678901234567890123456789012",
+                    [$"{JwtSettings.SectionName}:Issuer"] = "test-issuer",
+                    [$"{JwtSettings.SectionName}:Audience"] = "test-audience"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<DbContextOptions<WordleTrackerSupremeDbContext>>();
+                services.RemoveAll<WordleTrackerSupremeDbContext>();
+
+                services.AddDbContext<WordleTrackerSupremeDbContext>(options =>
+                    options.UseInMemoryDatabase($"auth-cookie-{Guid.NewGuid()}"));
+
+                using var scope = services.BuildServiceProvider().CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<WordleTrackerSupremeDbContext>();
+                dbContext.Database.EnsureCreated();
+            });
+        }
+    }
+}

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.spec.ts
@@ -43,4 +43,34 @@ describe('generated api request', () => {
 
 		expect(notifyUnauthorizedResponse).toHaveBeenCalledWith(true);
 	});
+
+	it('does not notify the auth layer when auth bootstrap returns 401', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			headers: new Headers({ 'Content-Type': 'application/json' }),
+			json: () => Promise.resolve({ message: 'Unauthorized' })
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await expect(
+			request(
+				{
+					BASE: 'http://api.test',
+					VERSION: '1',
+					WITH_CREDENTIALS: true,
+					CREDENTIALS: 'include',
+					TOKEN: undefined
+				},
+				{
+					method: 'GET',
+					url: '/api/Auth/me'
+				}
+			)
+		).rejects.toThrowError('Unauthorized');
+
+		expect(notifyUnauthorizedResponse).toHaveBeenCalledWith(false);
+	});
 });

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
@@ -331,7 +331,8 @@ export const request = <T>(
 					body: responseHeader ?? responseBody
 				};
 
-				notifyUnauthorizedResponse(response.status === 401);
+				const isAuthBootstrapRequest = options.url === '/api/Auth/me' || options.url === '/api/auth/me';
+				notifyUnauthorizedResponse(response.status === 401 && !isAuthBootstrapRequest);
 
 				catchErrorCodes(options, result);
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/core/request.ts
@@ -331,7 +331,7 @@ export const request = <T>(
 					body: responseHeader ?? responseBody
 				};
 
-				notifyUnauthorizedResponse(response.status === 401 && headers.has('Authorization'));
+				notifyUnauthorizedResponse(response.status === 401);
 
 				catchErrorCodes(options, result);
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api/index.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api/index.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OpenAPI } from '$lib/api-client';
+
+async function loadApiModuleAt(origin: string) {
+	vi.resetModules();
+	OpenAPI.BASE = '';
+	vi.stubGlobal('window', {
+		location: {
+			origin,
+			hostname: new URL(origin).hostname
+		}
+	});
+	return import('./index');
+}
+
+describe('api config', () => {
+	beforeEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	it('uses localhost for the local API fallback when served from localhost', async () => {
+		const { getApiBase } = await loadApiModuleAt('http://localhost:3000');
+
+		expect(getApiBase()).toBe('http://localhost:8080');
+	});
+
+	it('preserves 127.0.0.1 for the local API fallback when served from 127.0.0.1', async () => {
+		const { getApiBase } = await loadApiModuleAt('http://127.0.0.1:3000');
+
+		expect(getApiBase()).toBe('http://127.0.0.1:8080');
+	});
+
+	it('prefers the configured API base when VITE_API_BASE is set', async () => {
+		vi.stubEnv('VITE_API_BASE', 'https://api.example.test');
+		const { getApiBase } = await loadApiModuleAt('http://127.0.0.1:3000');
+
+		expect(getApiBase()).toBe('https://api.example.test');
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api/index.ts
@@ -11,7 +11,7 @@ const fallbackApiBase = (() => {
 	const origin = window.location.origin;
 	const hostname = window.location.hostname;
 	if (hostname === 'localhost' || hostname === '127.0.0.1') {
-		return 'http://localhost:8080';
+		return `http://${hostname}:8080`;
 	}
 
 	return origin;
@@ -25,9 +25,11 @@ function ensureBaseConfigured() {
 	baseConfigured = true;
 }
 
-export function configureApiClient(token: string | null) {
+export function configureApiClient() {
 	ensureBaseConfigured();
-	OpenAPI.TOKEN = token ?? undefined;
+	OpenAPI.TOKEN = undefined;
+	OpenAPI.WITH_CREDENTIALS = true;
+	OpenAPI.CREDENTIALS = 'include';
 }
 
 export function getApiBase() {
@@ -39,8 +41,8 @@ export function registerUnauthorizedHandler(handler: (() => void) | null) {
 	unauthorizedHandler = handler;
 }
 
-export function notifyUnauthorizedResponse(hasAuthorization: boolean) {
-	if (!hasAuthorization) {
+export function notifyUnauthorizedResponse(shouldNotify: boolean) {
+	if (!shouldNotify) {
 		return;
 	}
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
@@ -8,92 +8,107 @@ const mockAuthService = {
 };
 let unauthorizedHandler: (() => void) | null = null;
 
+const getApiBase = vi.fn(() => 'http://api.test');
+
 vi.mock('$lib/api-client/services/AuthService', () => ({
 	AuthService: mockAuthService
 }));
 
 vi.mock('$lib/api', () => ({
 	configureApiClient: vi.fn(),
+	getApiBase,
 	registerUnauthorizedHandler: vi.fn((handler: (() => void) | null) => {
 		unauthorizedHandler = handler;
 	})
 }));
 
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
 const { auth, signIn, signUp, signOut, bootstrapAuth } = await import('./store');
 
 describe('auth store', () => {
 	beforeEach(() => {
-		localStorage.clear();
+		sessionStorage.clear();
 		vi.clearAllMocks();
 		vi.spyOn(console, 'error').mockImplementation(() => {});
-		auth.set({ user: null, token: null, ready: true });
+		auth.set({ user: null, token: null, ready: true, error: null });
 	});
 
 	afterEach(() => {
-		localStorage.clear();
 		vi.restoreAllMocks();
 	});
 
-	it('signIn stores token and user', async () => {
+	it('signIn stores user without persisting a browser token', async () => {
 		mockAuthService.postApiAuthSignin.mockResolvedValue({
-			token: 'abc123',
 			player: {
 				id: '1',
 				displayName: 'Tester',
 				email: 't@example.com',
 				isAdmin: false,
 				createdOn: ''
-			}
+			},
+			token: null
 		});
 
 		await signIn('t@example.com', 'secret');
 
-		expect(localStorage.getItem('wts_auth_token')).toBe('abc123');
 		const state = get(auth);
 		expect(state.user?.displayName).toBe('Tester');
-		expect(state.token).toBe('abc123');
+		expect(state.token).toBeNull();
+		expect(localStorage.getItem('wts_auth_token')).toBeNull();
 	});
 
-	it('signUp stores token and user', async () => {
+	it('signUp stores user without persisting a browser token', async () => {
 		mockAuthService.postApiAuthSignup.mockResolvedValue({
-			token: 'xyz789',
 			player: {
 				id: '2',
 				displayName: 'Newbie',
 				email: 'n@example.com',
 				isAdmin: false,
 				createdOn: ''
-			}
+			},
+			token: null
 		});
 
 		await signUp('Newbie', 'n@example.com', 'secret');
 
-		expect(localStorage.getItem('wts_auth_token')).toBe('xyz789');
 		expect(get(auth).user?.displayName).toBe('Newbie');
+		expect(get(auth).token).toBeNull();
+		expect(localStorage.getItem('wts_auth_token')).toBeNull();
 	});
 
-	it('signOut clears token', () => {
-		localStorage.setItem('wts_auth_token', 'keepme');
-		signOut();
-		expect(localStorage.getItem('wts_auth_token')).toBeNull();
-		expect(get(auth).user).toBeNull();
-	});
+	it('signOut clears local auth state after calling the signout endpoint', async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			status: 204
+		});
+		auth.set({
+			user: {
+				id: '1',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '',
+				isAdmin: false
+			},
+			token: null,
+			ready: true,
+			error: null
+		});
 
-	it('bootstrapAuth clears expired token', async () => {
-		localStorage.setItem('wts_auth_token', 'expired');
-		mockAuthService.getApiAuthMe.mockRejectedValue(new Error('expired'));
+		await signOut();
 
-		await bootstrapAuth();
-
-		expect(localStorage.getItem('wts_auth_token')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith('http://api.test/api/auth/signout', {
+			method: 'POST',
+			credentials: 'include'
+		});
 		expect(get(auth).user).toBeNull();
 		expect(get(auth).token).toBeNull();
 	});
 
 	it('bootstrapAuth preserves a pending expiry error for the redirected sign-in page', async () => {
-		localStorage.setItem('wts_auth_token', 'expired');
 		sessionStorage.setItem('wts_auth_error', 'Session expired. Please sign in again.');
-		mockAuthService.getApiAuthMe.mockRejectedValue(new Error('expired'));
+		mockAuthService.getApiAuthMe.mockRejectedValue(new Error('Unauthorized'));
 
 		await bootstrapAuth();
 
@@ -101,8 +116,17 @@ describe('auth store', () => {
 		expect(sessionStorage.getItem('wts_auth_error')).toBe('Session expired. Please sign in again.');
 	});
 
-	it('bootstrapAuth maps admin flag', async () => {
-		localStorage.setItem('wts_auth_token', 'keep');
+	it('bootstrapAuth treats unauthorized as a signed-out session', async () => {
+		mockAuthService.getApiAuthMe.mockRejectedValue(new Error('Unauthorized'));
+
+		await bootstrapAuth();
+
+		expect(get(auth).user).toBeNull();
+		expect(get(auth).token).toBeNull();
+		expect(get(auth).error).toBeNull();
+	});
+
+	it('bootstrapAuth maps admin flag from the cookie-backed session', async () => {
 		mockAuthService.getApiAuthMe.mockResolvedValue({
 			id: '99',
 			displayName: 'Admin',
@@ -114,10 +138,10 @@ describe('auth store', () => {
 		await bootstrapAuth();
 
 		expect(get(auth).user?.isAdmin).toBe(true);
+		expect(get(auth).token).toBeNull();
 	});
 
 	it('unauthorized handler clears auth state and redirects to sign-in', () => {
-		localStorage.setItem('wts_auth_token', 'keepme');
 		auth.set({
 			user: {
 				id: '1',
@@ -126,14 +150,13 @@ describe('auth store', () => {
 				createdOn: '',
 				isAdmin: false
 			},
-			token: 'keepme',
+			token: null,
 			ready: true,
 			error: null
 		});
 
 		unauthorizedHandler?.();
 
-		expect(localStorage.getItem('wts_auth_token')).toBeNull();
 		expect(get(auth).user).toBeNull();
 		expect(get(auth).error).toBe('Session expired. Please sign in again.');
 	});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
@@ -1,30 +1,11 @@
 import { AuthService } from '$lib/api-client/services/AuthService';
-import { configureApiClient, registerUnauthorizedHandler } from '$lib/api';
+import { configureApiClient, getApiBase, registerUnauthorizedHandler } from '$lib/api';
 import { writable } from 'svelte/store';
 import type { AuthResponse as ApiAuthResponse } from '$lib/api-client/models/AuthResponse';
 import type { PlayerResponse as ApiPlayerResponse } from '$lib/api-client/models/PlayerResponse';
 import type { AuthState, Player } from './types';
 
-const TOKEN_STORAGE_KEY = 'wts_auth_token';
 const PENDING_AUTH_ERROR_KEY = 'wts_auth_error';
-
-function loadStoredToken(): string | null {
-	if (typeof localStorage === 'undefined') {
-		return null;
-	}
-	return localStorage.getItem(TOKEN_STORAGE_KEY);
-}
-
-function persistToken(token: string | null) {
-	if (typeof localStorage === 'undefined') {
-		return;
-	}
-	if (token) {
-		localStorage.setItem(TOKEN_STORAGE_KEY, token);
-	} else {
-		localStorage.removeItem(TOKEN_STORAGE_KEY);
-	}
-}
 
 function persistPendingAuthError(error: string | null) {
 	if (typeof sessionStorage === 'undefined') {
@@ -38,19 +19,6 @@ function persistPendingAuthError(error: string | null) {
 	}
 }
 
-function consumePendingAuthError(): string | null {
-	if (typeof sessionStorage === 'undefined') {
-		return null;
-	}
-
-	const error = sessionStorage.getItem(PENDING_AUTH_ERROR_KEY);
-	if (error) {
-		sessionStorage.removeItem(PENDING_AUTH_ERROR_KEY);
-	}
-
-	return error;
-}
-
 function loadPendingAuthError(): string | null {
 	if (typeof sessionStorage === 'undefined') {
 		return null;
@@ -59,31 +27,24 @@ function loadPendingAuthError(): string | null {
 	return sessionStorage.getItem(PENDING_AUTH_ERROR_KEY);
 }
 
-const initialToken = loadStoredToken();
-
 export const auth = writable<AuthState>({
 	user: null,
-	token: initialToken,
+	token: null,
 	ready: false,
 	error: null
 });
 
-configureApiClient(initialToken);
+configureApiClient();
 
-function setAuthState(
-	token: string | null,
-	user: Player | null,
-	error: string | null,
-	clearPendingAuthError = true
-) {
-	persistToken(token);
-	configureApiClient(token);
+function setAuthState(user: Player | null, error: string | null, clearPendingAuthError = true) {
+	configureApiClient();
 	if (clearPendingAuthError) {
 		persistPendingAuthError(null);
 	}
+
 	auth.set({
 		user,
-		token,
+		token: null,
 		ready: true,
 		error
 	});
@@ -104,7 +65,7 @@ function redirectToSignIn() {
 
 export function expireSession(message = 'Session expired. Please sign in again.') {
 	persistPendingAuthError(message);
-	setAuthState(null, null, message, false);
+	setAuthState(null, message, false);
 	redirectToSignIn();
 }
 
@@ -113,10 +74,14 @@ registerUnauthorizedHandler(() => {
 });
 
 function setAuthenticated(result: ApiAuthResponse) {
-	setAuthState(result.token ?? null, mapPlayer(result.player), null);
+	setAuthState(mapPlayer(result.player), null);
 }
 
-function mapPlayer(player: ApiPlayerResponse): Player {
+function mapPlayer(player: ApiPlayerResponse | undefined): Player | null {
+	if (!player) {
+		return null;
+	}
+
 	return {
 		id: player.id ?? '',
 		displayName: player.displayName ?? '',
@@ -127,22 +92,18 @@ function mapPlayer(player: ApiPlayerResponse): Player {
 }
 
 export async function bootstrapAuth() {
-	const token = loadStoredToken();
-	if (!token) {
-		auth.set({ user: null, token: null, ready: true, error: consumePendingAuthError() });
-		return;
-	}
-
-	configureApiClient(token);
-
 	try {
 		const player = await AuthService.getApiAuthMe();
-		auth.set({ user: mapPlayer(player), token, ready: true, error: null });
+		setAuthState(mapPlayer(player), null);
 	} catch (error) {
-		console.error('Auth bootstrap failed', error);
 		const pendingAuthError = loadPendingAuthError();
+		if (error instanceof Error && error.message === 'Unauthorized') {
+			setAuthState(null, pendingAuthError, pendingAuthError === null);
+			return;
+		}
+
+		console.error('Auth bootstrap failed', error);
 		setAuthState(
-			null,
 			null,
 			pendingAuthError ?? 'Session expired. Please sign in.',
 			pendingAuthError === null
@@ -164,6 +125,15 @@ export async function signUp(displayName: string, email: string, password: strin
 	setAuthenticated(result);
 }
 
-export function signOut() {
-	setAuthState(null, null, null);
+export async function signOut() {
+	try {
+		await fetch(`${getApiBase()}/api/auth/signout`, {
+			method: 'POST',
+			credentials: 'include'
+		});
+	} catch (error) {
+		console.error('Sign out request failed', error);
+	}
+
+	setAuthState(null, null);
 }

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -7,23 +7,16 @@ vi.mock('$lib/api', () => ({
 	notifyUnauthorizedResponse
 }));
 
-const openApiMock = { TOKEN: undefined as string | undefined };
-vi.mock('$lib/api-client', () => ({
-	OpenAPI: openApiMock
-}));
-
 // Lazy import after mocks so the module picks them up.
 const { enableEasyMode, fetchGameState, submitGuess } = await import('./api');
 
 describe('api helpers', () => {
 	beforeEach(() => {
-		openApiMock.TOKEN = undefined;
 		notifyUnauthorizedResponse.mockReset();
 		vi.restoreAllMocks();
 	});
 
-	it('includes bearer token when present', async () => {
-		openApiMock.TOKEN = 'abc123';
+	it('sends credentialed requests without a bearer header', async () => {
 		const mockResponse = {
 			ok: true,
 			status: 200,
@@ -34,8 +27,10 @@ describe('api helpers', () => {
 		await fetchGameState();
 
 		const call = fetchSpy.mock.calls[0];
-		const headers = (call[1] as RequestInit)?.headers as Headers;
-		expect(headers.get('Authorization')).toBe('Bearer abc123');
+		const init = call[1] as RequestInit;
+		const headers = init?.headers as Headers;
+		expect(init.credentials).toBe('include');
+		expect(headers.get('Authorization')).toBeNull();
 	});
 
 	it('throws error message from payload when request fails', async () => {
@@ -51,8 +46,7 @@ describe('api helpers', () => {
 		await expect(submitGuess('crane')).rejects.toThrowError('Nope');
 	});
 
-	it('notifies the auth layer when an authenticated request returns 401', async () => {
-		openApiMock.TOKEN = 'abc123';
+	it('notifies the auth layer when a credentialed request returns 401', async () => {
 		const mockResponse = {
 			ok: false,
 			status: 401,

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
@@ -1,5 +1,4 @@
 import { getApiBase, notifyUnauthorizedResponse } from '$lib/api';
-import { OpenAPI } from '$lib/api-client';
 import { StatsService } from '$lib/api-client/services/StatsService';
 import type { GameStateResponse, PlayerStatsResponse, SolutionsResponse } from './types';
 
@@ -7,17 +6,14 @@ async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 	const base = getApiBase();
 	const headers = new Headers(init.headers ?? {});
 	headers.set('Content-Type', 'application/json');
-	const token = OpenAPI.TOKEN;
-	if (token) {
-		headers.set('Authorization', `Bearer ${token}`);
-	}
 
 	const response = await fetch(`${base}${path}`, {
 		...init,
-		headers
+		headers,
+		credentials: 'include'
 	});
 
-	notifyUnauthorizedResponse(response.status === 401 && headers.has('Authorization'));
+	notifyUnauthorizedResponse(response.status === 401);
 
 	if (!response.ok) {
 		let message = 'Request failed';

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
@@ -57,7 +57,7 @@
 					</div>
 					<button
 						class="rounded-full border border-white/20 bg-white/10 px-4 py-2 font-medium text-white transition hover:border-white/40 hover:bg-white/15"
-						onclick={() => signOut()}
+						onclick={() => void signOut()}
 					>
 						Sign out
 					</button>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/leaderboard-unauth.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/leaderboard-unauth.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 
 test('leaderboard prompts for sign in when unauthenticated', async ({ page }) => {
 	await page.goto('/');
-	await page.evaluate(() => localStorage.clear());
 	await page.goto('/leaderboard');
 	await expect(page.getByText('Sign in to view the leaderboard.')).toBeVisible();
 	await expect(page.getByRole('main').getByRole('link', { name: 'Sign in' })).toBeVisible();

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/stats-unauth.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/stats-unauth.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 
 test('stats page prompts for sign in when unauthenticated', async ({ page }) => {
 	await page.goto('/');
-	await page.evaluate(() => localStorage.clear());
 	await page.goto('/stats');
 	await expect(page.getByText('Sign in to compare stats.')).toBeVisible();
 	await expect(page.getByRole('main').getByRole('link', { name: 'Sign in' })).toBeVisible();

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
@@ -9,10 +9,6 @@ test('submitting a guess only calls the API once', async ({ page }) => {
 			console.error('console', message.text());
 		}
 	});
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,
@@ -265,10 +261,6 @@ test('guess controls stay locked while a submission is in flight', async ({ page
 			console.error('console', message.text());
 		}
 	});
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-mode.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-mode.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test('players can switch to easy mode mid-game', async ({ page }) => {
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-empty.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-empty.spec.ts
@@ -5,10 +5,6 @@ test('leaderboard shows empty state when no entries', async ({ page }) => {
 		console.error('pageerror', error);
 	});
 
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
@@ -10,10 +10,6 @@ test('leaderboard shows ranked hard mode entries', async ({ page }) => {
 		}
 	});
 
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/signin.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/signin.spec.ts
@@ -1,9 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test('sign-in form shows validation and handles failed auth', async ({ page }) => {
-	await page.addInitScript(() => {
-		window.localStorage.clear();
-	});
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 401,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/signup.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/signup.spec.ts
@@ -9,8 +9,12 @@ test('sign-up form shows validation and backend error', async ({ page }) => {
 			console.error('console', message.text());
 		}
 	});
-	await page.addInitScript(() => {
-		window.localStorage.clear();
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 401,
+			contentType: 'application/json',
+			body: JSON.stringify({ message: 'Unauthorized' })
+		});
 	});
 	await page.route('**/api/Auth/signup', async (route) => {
 		await route.fulfill({

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/stats-empty.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/stats-empty.spec.ts
@@ -5,10 +5,6 @@ test('stats page shows empty state when no players match', async ({ page }) => {
 		console.error('pageerror', error);
 	});
 
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/stats.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/stats.spec.ts
@@ -10,10 +10,6 @@ test('stats page defaults to hard mode filters and excludes current player', asy
 		}
 	});
 
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/win-celebration.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/win-celebration.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test';
 
 test('shows confetti and win stats after solving', async ({ page }) => {
-	await page.addInitScript(() => {
-		window.localStorage.setItem('wts_auth_token', 'test-token');
-	});
-
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,


### PR DESCRIPTION
Closes #8

## Summary
- issue JWTs into an `HttpOnly` auth cookie on sign-up/sign-in and add a sign-out endpoint that clears it
- switch the Svelte app from `localStorage` bearer persistence to cookie-backed session bootstrap with credentialed requests
- update unit, backend integration, and UI tests that previously faked auth by writing `wts_auth_token` into `localStorage`

## Why
- bearer tokens stored in `localStorage` are directly readable by any future XSS payload
- moving the session token into an `HttpOnly` cookie removes that browser-storage exposure while still preserving page refresh auth bootstrap

## Verification
- `sudo docker-compose --profile tests run --rm tests-backend -lc "dotnet test Wordle.TrackerSupreme.sln --filter AuthCookieTests"`
- `npm test -- --run src/lib/auth/store.spec.ts src/lib/game/api.spec.ts`
- `npx playwright test tests/ui --project=chromium`
- `npm run lint`