### PR TITLE
[codex] Handle duplicate attempt conflicts cleanly

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Wordle.TrackerSupreme.Api.Models.Game;
 using Wordle.TrackerSupreme.Application.Services.Game;
+using Wordle.TrackerSupreme.Domain.Exceptions;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Domain.Services.Game;
 
@@ -57,6 +58,10 @@ public class GameController(
         {
             return BadRequest(new { message = ex.Message });
         }
+        catch (DuplicatePuzzleAttemptException ex)
+        {
+            return Conflict(new { message = ex.Message });
+        }
         catch (InvalidOperationException ex)
         {
             return Conflict(new { message = ex.Message });
@@ -80,6 +85,10 @@ public class GameController(
         catch (DailyPuzzleUnavailableException ex)
         {
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new { message = ex.Message });
+        }
+        catch (DuplicatePuzzleAttemptException ex)
+        {
+            return Conflict(new { message = ex.Message });
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Exceptions/DuplicatePuzzleAttemptException.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Exceptions/DuplicatePuzzleAttemptException.cs
@@ -1,0 +1,9 @@
+namespace Wordle.TrackerSupreme.Domain.Exceptions;
+
+public class DuplicatePuzzleAttemptException : InvalidOperationException
+{
+    public DuplicatePuzzleAttemptException()
+        : base("You already have an attempt for today's puzzle. Refresh to continue.")
+    {
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Wordle.TrackerSupreme.Domain.Exceptions;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Domain.Repositories;
 using Wordle.TrackerSupreme.Infrastructure.Database;
@@ -83,5 +84,46 @@ public class GameRepository(WordleTrackerSupremeDbContext dbContext) : IGameRepo
                 $"Could not save game changes due to a stale state. Entities: {string.Join(", ", details)}",
                 ex);
         }
+        catch (DbUpdateException ex)
+        {
+            if (await IsDuplicateAttemptConflict(ex, cancellationToken))
+            {
+                throw new DuplicatePuzzleAttemptException();
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<bool> IsDuplicateAttemptConflict(DbUpdateException ex, CancellationToken cancellationToken)
+    {
+        var pendingAttempts = ex.Entries
+            .Select(entry => entry.Entity)
+            .OfType<PlayerPuzzleAttempt>()
+            .Where(attempt => attempt.PlayerId != Guid.Empty && attempt.DailyPuzzleId != Guid.Empty)
+            .ToList();
+
+        if (pendingAttempts.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var attempt in pendingAttempts)
+        {
+            var hasExistingAttempt = await dbContext.Attempts
+                .AsNoTracking()
+                .AnyAsync(
+                    existing => existing.Id != attempt.Id &&
+                                existing.PlayerId == attempt.PlayerId &&
+                                existing.DailyPuzzleId == attempt.DailyPuzzleId,
+                    cancellationToken);
+
+            if (hasExistingAttempt)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeGameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeGameRepository.cs
@@ -8,6 +8,7 @@ public class FakeGameRepository : IGameRepository
     private readonly List<DailyPuzzle> _puzzles = [];
     private readonly List<PlayerPuzzleAttempt> _attempts = [];
     private readonly List<GuessAttempt> _guesses = [];
+    public Func<CancellationToken, Task>? SaveChangesHandler { get; set; }
 
     public Task AddAttempt(PlayerPuzzleAttempt attempt, CancellationToken cancellationToken)
     {
@@ -80,7 +81,15 @@ public class FakeGameRepository : IGameRepository
         return Task.CompletedTask;
     }
 
-    public Task SaveChanges(CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task SaveChanges(CancellationToken cancellationToken)
+    {
+        if (SaveChangesHandler is not null)
+        {
+            return SaveChangesHandler(cancellationToken);
+        }
+
+        return Task.CompletedTask;
+    }
 
     public IReadOnlyCollection<DailyPuzzle> Puzzles => _puzzles;
     public IReadOnlyCollection<PlayerPuzzleAttempt> Attempts => _attempts;

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wordle.TrackerSupreme.Api.Controllers;
 using Wordle.TrackerSupreme.Application.Services.Game;
+using Wordle.TrackerSupreme.Domain.Exceptions;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Domain.Services.Game;
 using Wordle.TrackerSupreme.Tests.Fakes;
@@ -108,6 +109,27 @@ public class GameControllerTests
             CancellationToken.None);
 
         result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task SubmitGuess_returns_conflict_with_duplicate_attempt_message_when_save_conflicts()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 11));
+        var repo = new FakeGameRepository
+        {
+            SaveChangesHandler = _ => Task.FromException(new DuplicatePuzzleAttemptException())
+        };
+        var controller = CreateController(repo, clock, "CRANE");
+
+        var result = await controller.SubmitGuess(
+            new Api.Models.Game.SubmitGuessRequest { Guess = "CRANE" },
+            CancellationToken.None);
+
+        var conflict = result.Result.Should().BeOfType<ConflictObjectResult>().Which;
+        conflict.Value.Should().BeEquivalentTo(new
+        {
+            message = "You already have an attempt for today's puzzle. Refresh to continue."
+        });
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Wordle.TrackerSupreme.Domain.Exceptions;
+using Wordle.TrackerSupreme.Domain.Models;
+using Wordle.TrackerSupreme.Infrastructure.Database;
+using Wordle.TrackerSupreme.Infrastructure.Repositories;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class GameRepositoryTests
+{
+    [Fact]
+    public async Task SaveChanges_translates_duplicate_attempt_unique_index_violation()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using (var setupContext = new WordleTrackerSupremeDbContext(options))
+        {
+            await setupContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE Attempts (
+                    Id TEXT NOT NULL PRIMARY KEY,
+                    PlayerId TEXT NOT NULL,
+                    DailyPuzzleId TEXT NOT NULL,
+                    Status INTEGER NOT NULL,
+                    PlayedInHardMode INTEGER NOT NULL,
+                    CreatedOn TEXT NOT NULL,
+                    CompletedOn TEXT NULL
+                );
+
+                CREATE UNIQUE INDEX IX_Attempts_PlayerId_DailyPuzzleId
+                    ON Attempts (PlayerId, DailyPuzzleId);
+                """);
+        }
+
+        var playerId = Guid.NewGuid();
+        var puzzleId = Guid.NewGuid();
+
+        await using (var seedContext = new WordleTrackerSupremeDbContext(options))
+        {
+            await seedContext.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO Attempts (Id, PlayerId, DailyPuzzleId, Status, PlayedInHardMode, CreatedOn, CompletedOn)
+                VALUES ({Guid.NewGuid()}, {playerId}, {puzzleId}, {(int)AttemptStatus.InProgress}, {true}, {DateTime.UtcNow}, NULL);
+                """);
+        }
+
+        await using var duplicateContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new GameRepository(duplicateContext);
+        await repository.AddAttempt(
+            new PlayerPuzzleAttempt
+            {
+                Id = Guid.NewGuid(),
+                PlayerId = playerId,
+                DailyPuzzleId = puzzleId,
+                Status = AttemptStatus.InProgress,
+                PlayedInHardMode = true,
+                CreatedOn = DateTime.UtcNow
+            },
+            CancellationToken.None);
+
+        var act = async () => await repository.SaveChanges(CancellationToken.None);
+
+        await act.Should().ThrowAsync<DuplicatePuzzleAttemptException>()
+            .WithMessage("You already have an attempt for today's puzzle. Refresh to continue.");
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameplayServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameplayServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wordle.TrackerSupreme.Application.Services.Game;
+using Wordle.TrackerSupreme.Domain.Exceptions;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Tests.Fakes;
 using Xunit;
@@ -151,6 +152,22 @@ public class GameplayServiceTests
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("Hard mode: guess must include all revealed letters.");
+    }
+
+    [Fact]
+    public async Task SubmitGuess_throws_duplicate_attempt_exception_when_save_detects_existing_attempt()
+    {
+        var repo = new FakeGameRepository
+        {
+            SaveChangesHandler = _ => Task.FromException(new DuplicatePuzzleAttemptException())
+        };
+        var gameplay = CreateService(repo, new FakeGameClock(new DateOnly(2025, 1, 9)), "APPLE");
+        var playerId = Guid.NewGuid();
+
+        var act = async () => await gameplay.SubmitGuess(playerId, "ALLEY");
+
+        await act.Should().ThrowAsync<DuplicatePuzzleAttemptException>()
+            .WithMessage("You already have an attempt for today's puzzle. Refresh to continue.");
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/game-duplicate-attempt.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/game-duplicate-attempt.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { signUp } from './helpers';
+
+test('shows a friendly message when a guess hits a duplicate-attempt conflict', async ({
+	page
+}) => {
+	await page.route('**/api/game/guess', async (route) => {
+		await route.fulfill({
+			status: 409,
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				message: "You already have an attempt for today's puzzle. Refresh to continue."
+			})
+		});
+	});
+
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E Conflict ${nonce}`,
+		email: `e2e.conflict.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	await page.keyboard.press('Enter');
+
+	await expect(
+		page.getByText("You already have an attempt for today's puzzle. Refresh to continue.")
+	).toBeVisible();
+	await expect(page.getByTestId('board-row-0')).toContainText('CRANE');
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
@@ -209,3 +209,72 @@ test('guess controls stay locked while a submission is in flight', async ({ page
 	await submitPromise;
 	await expect.poll(() => guessRequests).toBe(1);
 });
+
+test('duplicate attempt conflicts show the API message without clearing the row', async ({
+	page
+}) => {
+	page.on('pageerror', (error) => {
+		console.error('pageerror', error);
+	});
+	page.on('console', (message) => {
+		if (message.type() === 'error') {
+			console.error('console', message.text());
+		}
+	});
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: null,
+				solution: null
+			})
+		});
+	});
+
+	await page.route('**/api/game/guess', async (route) => {
+		await route.fulfill({
+			status: 409,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				message: "You already have an attempt for today's puzzle. Refresh to continue."
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	await page.keyboard.press('Enter');
+
+	await expect(
+		page.getByText("You already have an attempt for today's puzzle. Refresh to continue.")
+	).toBeVisible();
+	await expect(page.getByTestId('board-row-0')).toContainText('CRANE');
+});


### PR DESCRIPTION
Closes #21

## Summary
- translate duplicate attempt save failures into a dedicated `DuplicatePuzzleAttemptException` instead of leaking a raw database error path
- return a consistent 409 conflict message from the game controller for duplicate-attempt races on both guess submission and easy-mode creation
- add backend repository/service/controller coverage plus frontend UI and E2E regression tests for the friendly conflict message

## Why
A same-player duplicate attempt race could still trip the unique index on `(PlayerId, DailyPuzzleId)` and surface as an unhandled server error. This change converts that path into a user-facing conflict response that tells the player to refresh and continue their existing puzzle.

## Verification
- `docker-compose run --rm tests-backend`
- `docker-compose run --rm tests-frontend`
- `npm run lint` in `src/Wordle.TrackerSupreme.Web`
- seeded E2E run: bring up `db/api/web`, run `migrator`, run `seeder` with `Seeder__AllowReseed=true` and `Seeder__ResetDatabase=true`, then `E2E_BASE_URL=http://localhost:3000 npm run e2e` in `src/Wordle.TrackerSupreme.Web`
