### PR TITLE
[codex] Stop replaying reveal animations

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 	let error: string | null = null;
 	let initialized = false;
 	let submitting = false;
+	let animatedGuessId: string | null = null;
 	let showConfetti = false;
 	let showWinStats = false;
 	let winStats: PlayerStatsResponse | null = null;
@@ -89,6 +90,7 @@
 	async function loadState() {
 		loadingState = true;
 		error = null;
+		animatedGuessId = null;
 		try {
 			state = await fetchGameState();
 			message = null;
@@ -117,9 +119,12 @@
 		error = null;
 		message = null;
 		const previousStatus = currentState.attempt?.status ?? null;
+		const previousGuessId = currentState.attempt?.guesses.at(-1)?.guessId ?? null;
 		submitting = true;
 		try {
 			state = await submitGuess(normalized);
+			const latestGuessId = state.attempt?.guesses.at(-1)?.guessId ?? null;
+			animatedGuessId = latestGuessId !== previousGuessId ? latestGuessId : null;
 			guess = '';
 			message = null;
 			const nextStatus = state.attempt?.status ?? null;
@@ -177,6 +182,7 @@
 
 		error = null;
 		message = null;
+		animatedGuessId = null;
 		try {
 			state = await enableEasyMode();
 			message = 'Easy mode enabled for this puzzle.';
@@ -198,6 +204,22 @@
 			return `${base} border-white/15 bg-white/5 text-white/60`;
 		}
 		return `${base} border-white/10 bg-white/5 text-white/30`;
+	}
+
+	function tileAnimationClass(guessId: string, result: LetterResult) {
+		if (guessId !== animatedGuessId) {
+			return '';
+		}
+
+		return `animate-reveal reveal-${result.toLowerCase()}`;
+	}
+
+	function tileAnimationDelay(guessId: string, position: number) {
+		if (guessId !== animatedGuessId) {
+			return '';
+		}
+
+		return `animation-delay:${position * 220}ms`;
 	}
 
 	function keyState(letter: string): LetterResult | 'Used' | null {
@@ -381,8 +403,11 @@
 									{#if state.attempt?.guesses[rowIndex]}
 										{#each state.attempt.guesses[rowIndex].feedback as fb (fb.position)}
 											<div
-												class={`${tileClass(fb.result)} ${rowIndex === (state.attempt?.guesses.length ?? 0) - 1 ? `animate-reveal reveal-${fb.result.toLowerCase()}` : ''}`}
-												style={`${rowIndex === (state.attempt?.guesses.length ?? 0) - 1 ? `animation-delay:${fb.position * 220}ms` : ''}`}
+												class={`${tileClass(fb.result)} ${tileAnimationClass(state.attempt.guesses[rowIndex].guessId, fb.result)}`}
+												style={tileAnimationDelay(
+													state.attempt.guesses[rowIndex].guessId,
+													fb.position
+												)}
 											>
 												{fb.letter}
 											</div>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
@@ -96,6 +96,166 @@ test('submitting a guess only calls the API once', async ({ page }) => {
 	await expect.poll(() => guessRequests).toBe(1);
 });
 
+test('existing guesses do not replay the reveal animation on initial load', async ({ page }) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Absent' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Absent' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.locator('[data-testid="board-row-0"] > div')).toHaveCount(5);
+	const hasRevealAnimation = await page
+		.locator('[data-testid="board-row-0"] > div')
+		.evaluateAll((tiles) => tiles.some((tile) => tile.className.includes('animate-reveal')));
+
+	expect(hasRevealAnimation).toBe(false);
+});
+
+test('newly submitted guesses still animate the reveal row', async ({ page }) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: null,
+				solution: null
+			})
+		});
+	});
+
+	await page.route('**/api/game/guess', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Absent' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Absent' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	await page.keyboard.press('Enter');
+
+	await expect
+		.poll(async () =>
+			page
+				.locator('[data-testid="board-row-0"] > div')
+				.evaluateAll((tiles) => tiles.some((tile) => tile.className.includes('animate-reveal')))
+		)
+		.toBe(true);
+});
+
 test('guess controls stay locked while a submission is in flight', async ({ page }) => {
 	page.on('pageerror', (error) => {
 		console.error('pageerror', error);


### PR DESCRIPTION
Closes #39

## Summary
- animate board tiles only for the guess that was just returned from a successful submission
- clear the local animation marker on ordinary state loads and easy-mode toggles so existing rows stay static
- add UI regression coverage for both loaded game state and fresh submissions

## Verification
- `npm test -- --run`
- `npx playwright test tests/ui/game-guess.spec.ts --project=chromium`
- `npm run lint`
