### PR TITLE
Handle 'no puzzle today' with a friendly UI banner (#47)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
@@ -32,7 +32,7 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { message = ex.Message });
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
         }
     }
 
@@ -52,7 +52,7 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { message = ex.Message });
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
         }
         catch (ArgumentException ex)
         {
@@ -84,7 +84,7 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { message = ex.Message });
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
         }
         catch (DuplicatePuzzleAttemptException ex)
         {
@@ -111,7 +111,7 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { message = ex.Message });
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
         }
     }
 

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -13,7 +13,7 @@ vi.mock('$lib/api-client', () => ({
 }));
 
 // Lazy import after mocks so the module picks them up.
-const { enableEasyMode, fetchGameState, submitGuess } = await import('./api');
+const { ApiResponseError, enableEasyMode, fetchGameState, submitGuess } = await import('./api');
 
 describe('api helpers', () => {
 	beforeEach(() => {
@@ -79,6 +79,24 @@ describe('api helpers', () => {
 		const call = fetchSpy.mock.calls[0];
 		expect(call[0]).toBe('http://api.test/api/game/easy-mode');
 		expect((call[1] as RequestInit)?.method).toBe('POST');
+	});
+
+	it('throws ApiResponseError with code when response has a code field', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+			text: () =>
+				Promise.resolve(JSON.stringify({ code: 'puzzle_unavailable', message: 'No puzzle today.' }))
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		const err = await fetchGameState().catch((e) => e);
+		expect(err).toBeInstanceOf(ApiResponseError);
+		expect((err as ApiResponseError).status).toBe(503);
+		expect((err as ApiResponseError).code).toBe('puzzle_unavailable');
+		expect((err as ApiResponseError).message).toBe('No puzzle today.');
 	});
 
 	it('submits guesses with a JSON payload', async () => {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
@@ -3,6 +3,17 @@ import { OpenAPI } from '$lib/api-client';
 import { StatsService } from '$lib/api-client/services/StatsService';
 import type { GameStateResponse, PlayerStatsResponse, SolutionsResponse } from './types';
 
+export class ApiResponseError extends Error {
+	readonly status: number;
+	readonly code: string | undefined;
+
+	constructor(message: string, status: number, code?: string) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}
+
 async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 	const base = getApiBase();
 	const headers = new Headers(init.headers ?? {});
@@ -21,17 +32,23 @@ async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 
 	if (!response.ok) {
 		let message = 'Request failed';
+		let code: string | undefined;
 		const bodyText = await response.text();
 		if (bodyText) {
 			try {
 				const payload = JSON.parse(bodyText);
 				message = payload?.message ?? message;
+				code = payload?.code;
 			} catch {
 				message = bodyText;
 			}
 		}
 
-		throw new Error(message || `${response.status} ${response.statusText}`);
+		throw new ApiResponseError(
+			message || `${response.status} ${response.statusText}`,
+			response.status,
+			code
+		);
 	}
 
 	if (response.status === 204) {

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -2,7 +2,13 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { auth } from '$lib/auth/store';
-	import { enableEasyMode, fetchGameState, fetchMyStats, submitGuess } from '$lib/game/api';
+	import {
+		ApiResponseError,
+		enableEasyMode,
+		fetchGameState,
+		fetchMyStats,
+		submitGuess
+	} from '$lib/game/api';
 	import { getRevealDurationMs, shouldTriggerSolveCelebration } from '$lib/game/celebration';
 	import type { GameStateResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
 	import { onDestroy, onMount } from 'svelte';
@@ -13,6 +19,7 @@
 	let guess = '';
 	let message: string | null = null;
 	let error: string | null = null;
+	let noPuzzleToday = false;
 	let initialized = false;
 	let submitting = false;
 	let animatedGuessId: string | null = null;
@@ -90,12 +97,21 @@
 	async function loadState() {
 		loadingState = true;
 		error = null;
+		noPuzzleToday = false;
 		animatedGuessId = null;
 		try {
 			state = await fetchGameState();
 			message = null;
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Unable to load today’s puzzle.';
+			if (
+				err instanceof ApiResponseError &&
+				err.status === 503 &&
+				err.code === 'puzzle_unavailable'
+			) {
+				noPuzzleToday = true;
+			} else {
+				error = err instanceof Error ? err.message : "Unable to load today's puzzle.";
+			}
 		} finally {
 			loadingState = false;
 		}
@@ -360,8 +376,8 @@
 						Puzzle for {formatPuzzleDate(state?.puzzleDate)}
 					</h1>
 					<p class="mt-2 max-w-2xl text-sm text-slate-200/80">
-						Solve today’s word before noon to keep your streak alive. After 12:00 PM you can still
-						play, but those practice runs will be tracked separately and won’t change your stats.
+						Solve today's word before noon to keep your streak alive. After 12:00 PM you can still
+						play, but those practice runs will be tracked separately and won't change your stats.
 					</p>
 				</div>
 				<div class="flex flex-col items-start gap-3 sm:items-end">
@@ -388,7 +404,7 @@
 				<div
 					class="mt-8 rounded-2xl border border-white/10 bg-black/20 p-6 text-center text-slate-200/70"
 				>
-					Loading today’s puzzle...
+					Loading today's puzzle...
 				</div>
 			{:else if state}
 				<div class="mt-6">
@@ -510,12 +526,22 @@
 				</div>
 			{/if}
 
-			{#if !loadingState && !state && error}
+			{#if !loadingState && noPuzzleToday}
+				<div
+					class="mt-8 rounded-2xl border border-amber-400/50 bg-amber-500/10 p-6 text-center text-amber-100"
+					data-testid="no-puzzle-today"
+				>
+					<p class="text-base font-semibold">No puzzle available today.</p>
+					<p class="mt-1 text-sm text-amber-100/80">
+						Check back later — today's puzzle hasn't been scheduled yet.
+					</p>
+				</div>
+			{:else if !loadingState && !state && error}
 				<div
 					class="mt-8 rounded-2xl border border-rose-400/50 bg-rose-500/10 p-6 text-center text-sm text-rose-100"
 					data-testid="daily-puzzle-error"
 				>
-					{error ?? 'Unable to load today’s puzzle.'}
+					{error ?? "Unable to load today's puzzle."}
 				</div>
 			{/if}
 		</section>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/game-unavailable.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/game-unavailable.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { signUp } from './helpers';
 
-test('shows error when daily puzzle is unavailable', async ({ page }) => {
+test('shows error when daily puzzle is unavailable (generic 503)', async ({ page }) => {
 	await page.route('**/api/game/state', async (route) => {
 		await route.fulfill({
 			status: 503,
@@ -22,4 +22,28 @@ test('shows error when daily puzzle is unavailable', async ({ page }) => {
 	await expect(
 		page.getByText("Unable to retrieve today's puzzle. Please try again later.")
 	).toBeVisible();
+	await expect(page.getByTestId('daily-puzzle-error')).toBeVisible();
+});
+
+test('shows friendly banner when no puzzle is scheduled today', async ({ page }) => {
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 503,
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				code: 'puzzle_unavailable',
+				message: "Unable to retrieve today's puzzle. Please try again later."
+			})
+		});
+	});
+
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E NoPuzzle ${nonce}`,
+		email: `e2e.nopuzzle.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await expect(page.getByTestId('no-puzzle-today')).toBeVisible();
+	await expect(page.getByText('No puzzle available today.')).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Adds `code: "puzzle_unavailable"` to all 503 responses from `GameController` so the frontend can machine-read the cause
- Introduces `ApiResponseError` (extends `Error` with `.status` and `.code`) in `src/lib/game/api.ts` to carry this information through the call stack
- When the game-state endpoint returns `code === "puzzle_unavailable"`, the home page now shows an amber info panel ("No puzzle available today. Check back later.") instead of the generic red error banner
- Generic 503s without the code still route to the red error banner unchanged

## Test plan

- [x] Unit test: `ApiResponseError` carries `status` and `code` from a 503 payload (`api.spec.ts`)
- [x] E2E test (generic 503, no code): red error banner visible (`game-unavailable.spec.ts`)
- [x] E2E test (`puzzle_unavailable` code): amber "no puzzle today" panel visible (`game-unavailable.spec.ts`)
- [x] `npm run format && npm run lint` clean (only pre-existing `test-results/.last-run.json` permission warning)
- [x] All 28 Vitest unit tests pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)