### PR TITLE
Show completion message when revisiting a finished game (#40)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -103,16 +103,16 @@
 		animatedGuessId = null;
 		try {
 			state = await fetchGameState();
-			message = null;
+			message = completedMessage(state);
 		} catch (err) {
 			if (
 				err instanceof ApiResponseError &&
 				err.status === 503 &&
-				err.code === 'puzzle_unavailable'
+				err.code === ‘puzzle_unavailable’
 			) {
 				noPuzzleToday = true;
 			} else {
-				error = err instanceof Error ? err.message : "Unable to load today's puzzle.";
+				error = err instanceof Error ? err.message : "Unable to load today’s puzzle.";
 			}
 		} finally {
 			loadingState = false;
@@ -126,6 +126,19 @@
 			shakingRow = null;
 			shakeTimer = null;
 		}, 600);
+	}
+
+	function completedMessage(s: GameStateResponse | null): string | null {
+		if (!s?.attempt) return null;
+		const guessCount = s.attempt.guesses.length;
+		if (s.attempt.status === ‘Solved’) {
+			return `You solved it in ${guessCount} ${guessCount === 1 ? ‘guess’ : ‘guesses’}! Come back tomorrow.`;
+		}
+		if (s.attempt.status === ‘Failed’) {
+			const word = s.solutionRevealed ? ` The word was ${s.solution}.` : ‘’;
+			return `No more guesses — better luck tomorrow!${word}`;
+		}
+		return null;
 	}
 
 	async function handleGuess() {
@@ -456,7 +469,8 @@
 
 						{#if message}
 							<div
-								class="rounded-xl border border-emerald-300/40 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-50"
+								class={`rounded-xl border px-4 py-3 text-sm ${state?.attempt?.status === 'Failed' ? 'border-amber-300/40 bg-amber-400/10 text-amber-50' : 'border-emerald-300/40 bg-emerald-400/10 text-emerald-50'}`}
+								data-testid="completed-message"
 							>
 								{message}
 							</div>

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -108,11 +108,11 @@
 			if (
 				err instanceof ApiResponseError &&
 				err.status === 503 &&
-				err.code === ‘puzzle_unavailable’
+				err.code === 'puzzle_unavailable'
 			) {
 				noPuzzleToday = true;
 			} else {
-				error = err instanceof Error ? err.message : "Unable to load today’s puzzle.";
+				error = err instanceof Error ? err.message : "Unable to load today's puzzle.";
 			}
 		} finally {
 			loadingState = false;
@@ -131,11 +131,11 @@
 	function completedMessage(s: GameStateResponse | null): string | null {
 		if (!s?.attempt) return null;
 		const guessCount = s.attempt.guesses.length;
-		if (s.attempt.status === ‘Solved’) {
-			return `You solved it in ${guessCount} ${guessCount === 1 ? ‘guess’ : ‘guesses’}! Come back tomorrow.`;
+		if (s.attempt.status === 'Solved') {
+			return `You solved it in ${guessCount} ${guessCount === 1 ? 'guess' : 'guesses'}! Come back tomorrow.`;
 		}
-		if (s.attempt.status === ‘Failed’) {
-			const word = s.solutionRevealed ? ` The word was ${s.solution}.` : ‘’;
+		if (s.attempt.status === 'Failed') {
+			const word = s.solutionRevealed ? ` The word was ${s.solution}.` : '';
 			return `No more guesses — better luck tomorrow!${word}`;
 		}
 		return null;

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/completed-game.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/completed-game.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test';
+
+const authRoutes = async (page: import('@playwright/test').Page) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+};
+
+test('shows solved message when revisiting a completed winning attempt', async ({ page }) => {
+	await authRoutes(page);
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: true,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: false,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'Solved',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: '2025-01-01T00:05:00Z',
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Correct' },
+								{ position: 1, letter: 'R', result: 'Correct' },
+								{ position: 2, letter: 'A', result: 'Correct' },
+								{ position: 3, letter: 'N', result: 'Correct' },
+								{ position: 4, letter: 'E', result: 'Correct' }
+							]
+						}
+					]
+				},
+				solution: 'CRANE'
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	const msg = page.getByTestId('completed-message');
+	await expect(msg).toBeVisible();
+	await expect(msg).toContainText('You solved it in 1 guess');
+	await expect(msg).toContainText('Come back tomorrow');
+});
+
+test('shows failure message with solution when revisiting a failed attempt', async ({ page }) => {
+	await authRoutes(page);
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: true,
+				solutionRevealed: true,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: false,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'Failed',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: '2025-01-01T00:10:00Z',
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Absent' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Absent' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: 'STOMP'
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	const msg = page.getByTestId('completed-message');
+	await expect(msg).toBeVisible();
+	await expect(msg).toContainText('better luck tomorrow');
+	await expect(msg).toContainText('STOMP');
+});


### PR DESCRIPTION
## Summary

- Adds a `completedMessage()` helper in `+page.svelte` that produces a contextual banner when loading a state where the attempt is already `Solved` or `Failed`
- **Solved**: emerald panel — "You solved it in N guess(es)! Come back tomorrow."
- **Failed** (solution revealed): amber panel — "No more guesses — better luck tomorrow! The word was XXXXX."
- `data-testid="completed-message"` added for Playwright targeting

Previously the game board silently showed the completed guess grid with all inputs disabled and no explanation.

## Test plan

- [x] UI test: solved re-visit shows green win message with guess count
- [x] UI test: failed re-visit shows amber message with the solution word
- [x] `npm run format && npm run lint` clean (only pre-existing `.last-run.json` permission warning)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)