### PR TITLE
Add shake animation on board row when a guess is rejected (#48)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -23,6 +23,8 @@
 	let confettiPieces: ConfettiPiece[] = [];
 	let confettiTimer: ReturnType<typeof setTimeout> | null = null;
 	let statsTimer: ReturnType<typeof setTimeout> | null = null;
+	let shakingRow: number | null = null;
+	let shakeTimer: ReturnType<typeof setTimeout> | null = null;
 	const keyboardRows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
 	const confettiDurationMs = 1200;
 
@@ -101,6 +103,15 @@
 		}
 	}
 
+	function triggerShake() {
+		if (shakeTimer) clearTimeout(shakeTimer);
+		shakingRow = state?.attempt?.guesses.length ?? 0;
+		shakeTimer = setTimeout(() => {
+			shakingRow = null;
+			shakeTimer = null;
+		}, 600);
+	}
+
 	async function handleGuess() {
 		if (isGuessInputLocked()) {
 			return;
@@ -113,6 +124,7 @@
 
 		if (normalized.length !== targetLength) {
 			error = `Guesses must be ${targetLength} letters.`;
+			triggerShake();
 			return;
 		}
 
@@ -133,6 +145,7 @@
 			}
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Unable to submit guess.';
+			triggerShake();
 		} finally {
 			submitting = false;
 		}
@@ -396,7 +409,7 @@
 						<div class="grid grid-rows-6 gap-1.5">
 							{#each Array(state.maxGuesses).keys() as rowIndex (rowIndex)}
 								<div
-									class="grid justify-center gap-1.5"
+									class={`grid justify-center gap-1.5${shakingRow === rowIndex ? ' animate-shake' : ''}`}
 									style={`grid-template-columns: repeat(${state.wordLength}, 3.5rem);`}
 									data-testid={`board-row-${rowIndex}`}
 								>
@@ -611,6 +624,35 @@
 		100% {
 			transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot));
 			opacity: 0;
+		}
+	}
+
+	:global(.animate-shake) {
+		animation: shake 600ms ease-in-out;
+	}
+
+	@keyframes shake {
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		15% {
+			transform: translateX(-8px);
+		}
+		30% {
+			transform: translateX(7px);
+		}
+		45% {
+			transform: translateX(-6px);
+		}
+		60% {
+			transform: translateX(5px);
+		}
+		75% {
+			transform: translateX(-3px);
+		}
+		90% {
+			transform: translateX(2px);
 		}
 	}
 </style>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-guess.spec.ts
@@ -438,3 +438,50 @@ test('duplicate attempt conflicts show the API message without clearing the row'
 	).toBeVisible();
 	await expect(page.getByTestId('board-row-0')).toContainText('CRANE');
 });
+
+test('shakes the active row when the guess length is wrong', async ({ page }) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: null,
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await page.click('body');
+	await page.keyboard.type('AB');
+	await page.keyboard.press('Enter');
+
+	const activeRow = page.getByTestId('board-row-0');
+	await expect(activeRow).toHaveClass(/animate-shake/);
+	await expect(page.getByText('Guesses must be 5 letters.')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- When a guess is rejected (wrong length, invalid word, hard-mode constraint), the active board row shakes horizontally for 600 ms
- A `triggerShake()` helper records `shakingRow` (the current active row index) and clears it after the animation completes
- The `animate-shake` class is applied to the matching row in the board template
- `@keyframes shake` does a multi-step X translation (±8 px tapering to 0), matching the feel of the original Wordle game
- Called from both the length-check early-return path and the API submission catch block, so all rejection paths trigger the animation

## Test plan

- [x] UI test: submitting a 2-letter guess adds `animate-shake` class to `board-row-0` and shows the length error message
- [x] `npm run format && npm run lint` clean (only pre-existing `.last-run.json` permission warning)
- [x] All 28 Vitest unit tests pass

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)