### PR TITLE
Fix #12: Route AuthController through IPlayerRepository

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -3,37 +3,34 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Wordle.TrackerSupreme.Api.Auth;
 using Wordle.TrackerSupreme.Api.Models.Auth;
 using Wordle.TrackerSupreme.Domain.Models;
-using Wordle.TrackerSupreme.Infrastructure.Database;
+using Wordle.TrackerSupreme.Domain.Repositories;
 
 namespace Wordle.TrackerSupreme.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
 public class AuthController(
-    WordleTrackerSupremeDbContext dbContext,
+    IPlayerRepository playerRepository,
     JwtTokenService tokenService,
     PasswordHasher<Player> passwordHasher)
     : ControllerBase
 {
     [EnableRateLimiting(AuthRateLimiting.PolicyName)]
     [HttpPost("signup")]
-    public async Task<ActionResult<AuthResponse>> SignUp([FromBody] SignUpRequest request)
+    public async Task<ActionResult<AuthResponse>> SignUp([FromBody] SignUpRequest request, CancellationToken cancellationToken)
     {
         var displayName = request.DisplayName.Trim();
         var email = request.Email.Trim().ToLowerInvariant();
 
-        var exists = await dbContext.Players.AnyAsync(p => p.DisplayName == displayName);
-        if (exists)
+        if (await playerRepository.IsDisplayNameTaken(displayName, null, cancellationToken))
         {
             return Conflict(new { message = "Display name is already taken." });
         }
 
-        var emailExists = await dbContext.Players.AnyAsync(p => p.Email == email);
-        if (emailExists)
+        if (await playerRepository.IsEmailTaken(email, null, cancellationToken))
         {
             return Conflict(new { message = "Email is already registered." });
         }
@@ -49,8 +46,7 @@ public class AuthController(
 
         player.PasswordHash = passwordHasher.HashPassword(player, request.Password);
 
-        dbContext.Players.Add(player);
-        await dbContext.SaveChangesAsync();
+        await playerRepository.AddPlayer(player, cancellationToken);
 
         var token = tokenService.CreateToken(player);
         return Ok(new AuthResponse(MapPlayer(player), token));
@@ -58,11 +54,11 @@ public class AuthController(
 
     [EnableRateLimiting(AuthRateLimiting.PolicyName)]
     [HttpPost("signin")]
-    public async Task<ActionResult<AuthResponse>> SignIn([FromBody] SignInRequest request)
+    public async Task<ActionResult<AuthResponse>> SignIn([FromBody] SignInRequest request, CancellationToken cancellationToken)
     {
         var email = request.Email.Trim().ToLowerInvariant();
 
-        var player = await dbContext.Players.FirstOrDefaultAsync(p => p.Email == email);
+        var player = await playerRepository.GetPlayerByEmail(email, cancellationToken);
 
         if (player is null)
         {
@@ -81,7 +77,7 @@ public class AuthController(
 
     [Authorize]
     [HttpGet("me")]
-    public async Task<ActionResult<PlayerResponse>> GetCurrentPlayer()
+    public async Task<ActionResult<PlayerResponse>> GetCurrentPlayer(CancellationToken cancellationToken)
     {
         var playerIdClaim = User.FindFirstValue("playerId");
         if (!Guid.TryParse(playerIdClaim, out var playerId))
@@ -89,7 +85,7 @@ public class AuthController(
             return Unauthorized();
         }
 
-        var player = await dbContext.Players.FirstOrDefaultAsync(p => p.Id == playerId);
+        var player = await playerRepository.GetPlayer(playerId, cancellationToken);
         if (player is null)
         {
             return Unauthorized();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IPlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IPlayerRepository.cs
@@ -5,10 +5,12 @@ namespace Wordle.TrackerSupreme.Domain.Repositories;
 public interface IPlayerRepository
 {
     Task<Player?> GetPlayer(Guid playerId, CancellationToken cancellationToken);
+    Task<Player?> GetPlayerByEmail(string email, CancellationToken cancellationToken);
     Task<Player?> GetPlayerWithAttempts(Guid playerId, CancellationToken cancellationToken);
     Task<Player?> GetPlayerWithAttemptsAndGuesses(Guid playerId, CancellationToken cancellationToken);
     Task<List<Player>> GetPlayers(CancellationToken cancellationToken);
     Task<List<Player>> GetPlayersWithAttempts(CancellationToken cancellationToken);
+    Task AddPlayer(Player player, CancellationToken cancellationToken);
     Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken);
     Task<bool> IsEmailTaken(string email, Guid? excludePlayerId, CancellationToken cancellationToken);
     Task SaveChanges(CancellationToken cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
@@ -10,6 +10,9 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
     public Task<Player?> GetPlayer(Guid playerId, CancellationToken cancellationToken)
         => dbContext.Players.FirstOrDefaultAsync(p => p.Id == playerId, cancellationToken);
 
+    public Task<Player?> GetPlayerByEmail(string email, CancellationToken cancellationToken)
+        => dbContext.Players.FirstOrDefaultAsync(p => p.Email == email, cancellationToken);
+
     public Task<Player?> GetPlayerWithAttempts(Guid playerId, CancellationToken cancellationToken)
         => dbContext.Players
             .Include(p => p.Attempts)
@@ -29,6 +32,12 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
 
     public Task<List<Player>> GetPlayers(CancellationToken cancellationToken)
         => dbContext.Players.ToListAsync(cancellationToken);
+
+    public async Task AddPlayer(Player player, CancellationToken cancellationToken)
+    {
+        dbContext.Players.Add(player);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 
     public Task<List<Player>> GetPlayersWithAttempts(CancellationToken cancellationToken)
         => dbContext.Players

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
@@ -254,6 +254,11 @@ public class AdminServiceTests
             return Task.FromResult(_players.FirstOrDefault(player => player.Id == playerId));
         }
 
+        public Task<Player?> GetPlayerByEmail(string email, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_players.FirstOrDefault(player => player.Email == email));
+        }
+
         public Task<Player?> GetPlayerWithAttempts(Guid playerId, CancellationToken cancellationToken)
         {
             return Task.FromResult(_players.FirstOrDefault(player => player.Id == playerId));
@@ -272,6 +277,12 @@ public class AdminServiceTests
         public Task<List<Player>> GetPlayersWithAttempts(CancellationToken cancellationToken)
         {
             return Task.FromResult(_players.ToList());
+        }
+
+        public Task AddPlayer(Player player, CancellationToken cancellationToken)
+        {
+            _players.Add(player);
+            return Task.CompletedTask;
         }
 
         public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
@@ -1,0 +1,212 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Wordle.TrackerSupreme.Api.Auth;
+using Wordle.TrackerSupreme.Api.Controllers;
+using Wordle.TrackerSupreme.Api.Models.Auth;
+using Wordle.TrackerSupreme.Domain.Models;
+using Wordle.TrackerSupreme.Domain.Repositories;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class AuthControllerTests
+{
+    // Test-only placeholder values — not real credentials
+    private const string TestJwtSigningKey = "test-signing-key-at-least-32-chars-long";
+    private const string TestCredential = "Password1";
+
+    private static AuthController CreateController(
+        IPlayerRepository repository,
+        ClaimsPrincipal? user = null)
+    {
+        var signingKey = TestJwtSigningKey;
+        var jwtSettings = Options.Create(new JwtSettings
+        {
+            Secret = signingKey,
+            Issuer = "test",
+            Audience = "test",
+            ExpiryMinutes = 60
+        });
+
+        var controller = new AuthController(
+            repository,
+            new JwtTokenService(jwtSettings),
+            new PasswordHasher<Player>())
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = user ?? new ClaimsPrincipal()
+                }
+            }
+        };
+
+        return controller;
+    }
+
+    [Fact]
+    public async Task SignUp_creates_player_and_returns_ok_with_token()
+    {
+        var repo = new FakeAuthRepository();
+        var controller = CreateController(repo);
+
+        var result = await controller.SignUp(
+            new SignUpRequest { DisplayName = "Alice", Email = "alice@example.com", Password = TestCredential },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        repo.Players.Should().ContainSingle(p => p.Email == "alice@example.com");
+    }
+
+    [Fact]
+    public async Task SignUp_returns_conflict_when_display_name_is_taken()
+    {
+        var existing = new Player
+        {
+            Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = ""
+        };
+        var repo = new FakeAuthRepository([existing]);
+        var controller = CreateController(repo);
+
+        var result = await controller.SignUp(
+            new SignUpRequest { DisplayName = "Alice", Email = "new@example.com", Password = TestCredential },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task SignUp_returns_conflict_when_email_is_taken()
+    {
+        var existing = new Player
+        {
+            Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = ""
+        };
+        var repo = new FakeAuthRepository([existing]);
+        var controller = CreateController(repo);
+
+        var result = await controller.SignUp(
+            new SignUpRequest { DisplayName = "Bob", Email = "alice@example.com", Password = TestCredential },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task SignIn_returns_ok_with_token_for_valid_credentials()
+    {
+        var hasher = new PasswordHasher<Player>();
+        var player = new Player { Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = "" };
+        player.PasswordHash = hasher.HashPassword(player, TestCredential);
+        var repo = new FakeAuthRepository([player]);
+        var controller = CreateController(repo);
+
+        var result = await controller.SignIn(
+            new SignInRequest { Email = "alice@example.com", Password = TestCredential },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task SignIn_returns_unauthorized_for_wrong_password()
+    {
+        var hasher = new PasswordHasher<Player>();
+        var player = new Player { Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = "" };
+        player.PasswordHash = hasher.HashPassword(player, TestCredential);
+        var repo = new FakeAuthRepository([player]);
+        var controller = CreateController(repo);
+
+        var result = await controller.SignIn(
+            new SignInRequest { Email = "alice@example.com", Password = TestCredential + "_wrong" },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task SignIn_returns_unauthorized_for_unknown_email()
+    {
+        var repo = new FakeAuthRepository();
+        var controller = CreateController(repo);
+
+        var result = await controller.SignIn(
+            new SignInRequest { Email = "nobody@example.com", Password = TestCredential },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetCurrentPlayer_returns_player_for_valid_jwt_claim()
+    {
+        var player = new Player { Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = "" };
+        var repo = new FakeAuthRepository([player]);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("playerId", player.Id.ToString())], "Test"));
+        var controller = CreateController(repo, user);
+
+        var result = await controller.GetCurrentPlayer(CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Which;
+        var response = ok.Value.Should().BeOfType<PlayerResponse>().Which;
+        response.DisplayName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task GetCurrentPlayer_returns_unauthorized_when_player_not_found()
+    {
+        var repo = new FakeAuthRepository();
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("playerId", Guid.NewGuid().ToString())], "Test"));
+        var controller = CreateController(repo, user);
+
+        var result = await controller.GetCurrentPlayer(CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    private sealed class FakeAuthRepository : IPlayerRepository
+    {
+        public List<Player> Players { get; }
+
+        public FakeAuthRepository(List<Player>? players = null) => Players = players ?? [];
+
+        public Task<Player?> GetPlayer(Guid playerId, CancellationToken ct)
+            => Task.FromResult(Players.FirstOrDefault(p => p.Id == playerId));
+
+        public Task<Player?> GetPlayerByEmail(string email, CancellationToken ct)
+            => Task.FromResult(Players.FirstOrDefault(p => p.Email == email));
+
+        public Task<Player?> GetPlayerWithAttempts(Guid playerId, CancellationToken ct)
+            => Task.FromResult(Players.FirstOrDefault(p => p.Id == playerId));
+
+        public Task<Player?> GetPlayerWithAttemptsAndGuesses(Guid playerId, CancellationToken ct)
+            => Task.FromResult(Players.FirstOrDefault(p => p.Id == playerId));
+
+        public Task<List<Player>> GetPlayers(CancellationToken ct) => Task.FromResult(Players.ToList());
+
+        public Task<List<Player>> GetPlayersWithAttempts(CancellationToken ct) => Task.FromResult(Players.ToList());
+
+        public Task AddPlayer(Player player, CancellationToken ct)
+        {
+            Players.Add(player);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken ct)
+            => Task.FromResult(Players.Any(p =>
+                p.DisplayName == displayName && (excludePlayerId == null || p.Id != excludePlayerId)));
+
+        public Task<bool> IsEmailTaken(string email, Guid? excludePlayerId, CancellationToken ct)
+            => Task.FromResult(Players.Any(p =>
+                p.Email == email && (excludePlayerId == null || p.Id != excludePlayerId)));
+
+        public Task SaveChanges(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
@@ -173,6 +173,11 @@ public class StatsControllerTests
             return Task.FromResult(_players.FirstOrDefault(player => player.Id == playerId));
         }
 
+        public Task<Player?> GetPlayerByEmail(string email, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_players.FirstOrDefault(player => player.Email == email));
+        }
+
         public Task<Player?> GetPlayerWithAttempts(Guid playerId, CancellationToken cancellationToken)
         {
             return Task.FromResult(_players.FirstOrDefault(player => player.Id == playerId));
@@ -191,6 +196,12 @@ public class StatsControllerTests
         public Task<List<Player>> GetPlayersWithAttempts(CancellationToken cancellationToken)
         {
             return Task.FromResult(_players);
+        }
+
+        public Task AddPlayer(Player player, CancellationToken cancellationToken)
+        {
+            _players.Add(player);
+            return Task.CompletedTask;
         }
 
         public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Adds `GetPlayerByEmail` and `AddPlayer` to `IPlayerRepository` and implements them in `PlayerRepository`
- Rewrites `AuthController` to inject `IPlayerRepository` instead of directly using `WordleTrackerSupremeDbContext`, fixing the architecture violation
- All fake repositories in tests updated to implement the two new interface methods
- Adds `AuthControllerTests` with 7 unit tests covering sign-up (happy path, display-name conflict, email conflict), sign-in (valid credentials, wrong credential, unknown email), and `GetCurrentPlayer` (valid claim, player not found)

## Test plan
- [ ] All 55 backend unit tests pass (`docker compose --profile tests run --rm tests-backend`)
- [ ] `AuthControllerTests` — 7 new tests all green
- [ ] No `DbContext` reference remains in `AuthController`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)