### PR TITLE
Add E2E test: win the daily puzzle end-to-end (#36)

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -47,7 +47,8 @@ cleanup() {
 
 trap cleanup EXIT
 
-"${compose[@]}" --profile app up -d --build db api web
+ASPNETCORE_ENVIRONMENT=Development \
+  "${compose[@]}" --profile app up -d --build db api web
 
 "${compose[@]}" logs -f --no-color api >"$ARTIFACT_DIR/backend.log" 2>&1 &
 BACKEND_LOG_PID=$!

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/game-win.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/game-win.spec.ts
@@ -59,10 +59,11 @@ function getTodaySolution(): string {
 		'VOICE',
 		'YEARN'
 	];
-	const anchor = new Date('2025-01-01');
-	const today = new Date();
-	today.setHours(0, 0, 0, 0);
-	anchor.setHours(0, 0, 0, 0);
+	// Use the local-time constructor so anchor and today are both in local
+	// midnight, matching the backend WordSelector which works in server-local time.
+	const anchor = new Date(2025, 0, 1); // 1 Jan 2025, local midnight
+	const now = new Date();
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // local midnight
 	const msPerDay = 24 * 60 * 60 * 1000;
 	const offset = Math.round((today.getTime() - anchor.getTime()) / msPerDay);
 	const index = ((offset % words.length) + words.length) % words.length;
@@ -77,7 +78,7 @@ test('player wins the daily puzzle and sees victory stats', async ({ page }) => 
 		password: 'Supreme!234'
 	});
 
-	await page.getByText("Loading today's puzzle...").waitFor({ state: 'hidden' });
+	await page.getByTestId('board-row-0').waitFor({ state: 'visible' });
 
 	const solution = getTodaySolution();
 
@@ -103,7 +104,7 @@ test('player wins the daily puzzle in easy mode and sees victory stats', async (
 		password: 'Supreme!234'
 	});
 
-	await page.getByText("Loading today's puzzle...").waitFor({ state: 'hidden' });
+	await page.getByTestId('board-row-0').waitFor({ state: 'visible' });
 
 	// Opt into easy mode before guessing
 	await page.getByTestId('enable-easy-mode').click();

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/game-win.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/game-win.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+import { signUp } from './helpers';
+
+/**
+ * Compute today's puzzle solution using the same deterministic formula as the backend
+ * WordSelector. The word list and anchor date must stay in sync with
+ * Wordle.TrackerSupreme.Application.Services.Game.WordSelector.
+ */
+function getTodaySolution(): string {
+	const words = [
+		'SLATE',
+		'CRANE',
+		'BRAVE',
+		'TRAIN',
+		'SHINE',
+		'GLASS',
+		'FROND',
+		'QUIET',
+		'PLANT',
+		'ROAST',
+		'TRAIL',
+		'SNAKE',
+		'CLOUD',
+		'BRINK',
+		'DRIVE',
+		'STEAM',
+		'WATER',
+		'GRAPE',
+		'PANEL',
+		'CROWN',
+		'STARE',
+		'GHOST',
+		'PLUSH',
+		'MONEY',
+		'LIGHT',
+		'RANGE',
+		'BRICK',
+		'FLAME',
+		'WOUND',
+		'SCORE',
+		'CHIME',
+		'PRIDE',
+		'STONE',
+		'HOUSE',
+		'PIVOT',
+		'CHALK',
+		'FROST',
+		'BLINK',
+		'SHARD',
+		'TOWEL',
+		'NORTH',
+		'SOUTH',
+		'EAGER',
+		'QUEST',
+		'FRAME',
+		'GRIND',
+		'WRIST',
+		'TRICK',
+		'VOICE',
+		'YEARN'
+	];
+	const anchor = new Date('2025-01-01');
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+	anchor.setHours(0, 0, 0, 0);
+	const msPerDay = 24 * 60 * 60 * 1000;
+	const offset = Math.round((today.getTime() - anchor.getTime()) / msPerDay);
+	const index = ((offset % words.length) + words.length) % words.length;
+	return words[index];
+}
+
+test('player wins the daily puzzle and sees victory stats', async ({ page }) => {
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E Win ${nonce}`,
+		email: `e2e.win.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await page.getByText("Loading today's puzzle...").waitFor({ state: 'hidden' });
+
+	const solution = getTodaySolution();
+
+	await page.click('body');
+	await page.keyboard.type(solution);
+	await page.keyboard.press('Enter');
+
+	// Wait for the win-stats panel to appear (tile flip + confetti delay ~1.5 s)
+	const winStats = page.getByTestId('win-stats');
+	await expect(winStats).toBeVisible({ timeout: 10_000 });
+
+	// Victory stats headings are visible
+	await expect(winStats.getByText('Wins')).toBeVisible();
+	await expect(winStats.getByText('Current streak')).toBeVisible();
+	await expect(winStats.getByText('Avg guesses')).toBeVisible();
+});
+
+test('player wins the daily puzzle in easy mode and sees victory stats', async ({ page }) => {
+	const nonce = Date.now();
+	await signUp(page, {
+		displayName: `E2E WinEasy ${nonce}`,
+		email: `e2e.wineasy.${nonce}@example.com`,
+		password: 'Supreme!234'
+	});
+
+	await page.getByText("Loading today's puzzle...").waitFor({ state: 'hidden' });
+
+	// Opt into easy mode before guessing
+	await page.getByTestId('enable-easy-mode').click();
+	await expect(page.getByText('Easy mode enabled for this puzzle.')).toBeVisible();
+
+	const solution = getTodaySolution();
+
+	await page.click('body');
+	await page.keyboard.type(solution);
+	await page.keyboard.press('Enter');
+
+	const winStats = page.getByTestId('win-stats');
+	await expect(winStats).toBeVisible({ timeout: 10_000 });
+	await expect(winStats.getByText('Wins')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- Adds `game-win.spec.ts` with two Playwright E2E tests that cover the core happy path: a player wins the daily puzzle and sees the victory stats panel.
- Today's puzzle solution is computed in the test using the same deterministic formula as `WordSelector` on the backend (50-word list, rotating by date offset from 2025-01-01), so no mocking or seeding is needed.
- Test 1: default hard mode — sign up, submit solution, assert `win-stats` panel and its headings are visible within 10 s.
- Test 2: easy mode — same flow but clicks "Enable easy mode" first.

## Test plan
- [ ] `docker compose --profile tests run --rm tests-frontend` — new specs run without error (requires a running backend+db for E2E)
- [ ] `./scripts/e2e.sh` — full E2E suite passes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)