### PR TITLE
Fix false session-expiry banner for unauthenticated users

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.spec.ts
@@ -160,4 +160,13 @@ describe('auth store', () => {
 		expect(get(auth).user).toBeNull();
 		expect(get(auth).error).toBe('Session expired. Please sign in again.');
 	});
+
+	it('unauthorized handler is a no-op when there is no active user session', () => {
+		auth.set({ user: null, token: null, ready: true, error: null });
+
+		unauthorizedHandler?.();
+
+		expect(get(auth).user).toBeNull();
+		expect(get(auth).error).toBeNull();
+	});
 });

--- a/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/auth/store.ts
@@ -1,6 +1,6 @@
 import { AuthService } from '$lib/api-client/services/AuthService';
 import { configureApiClient, getApiBase, registerUnauthorizedHandler } from '$lib/api';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { AuthResponse as ApiAuthResponse } from '$lib/api-client/models/AuthResponse';
 import type { PlayerResponse as ApiPlayerResponse } from '$lib/api-client/models/PlayerResponse';
 import type { AuthState, Player } from './types';
@@ -70,7 +70,9 @@ export function expireSession(message = 'Session expired. Please sign in again.'
 }
 
 registerUnauthorizedHandler(() => {
-	expireSession();
+	if (get(auth).user !== null) {
+		expireSession();
+	}
 });
 
 function setAuthenticated(result: ApiAuthResponse) {


### PR DESCRIPTION
## Summary

- After the cookie-auth migration (PR #54), the unauthorized handler fired for **any** non-bootstrap 401 — including requests from unauthenticated users visiting protected pages (e.g. `/leaderboard`)
- This caused the "Session expired. Please sign in again." banner and redirect to appear even for users who never had a session, breaking the `leaderboard-unauth` E2E test

## Root cause

`request.ts` changed the 401 condition from `headers.has('Authorization')` (always false with cookie auth) to `!isAuthBootstrapRequest`. This meant any 401 from a protected endpoint would trigger `expireSession()` — even when there was no user at all.

## Fix

Guard the `registerUnauthorizedHandler` callback: only call `expireSession()` when `get(auth).user !== null`, i.e., when there was an actual authenticated session that expired. Unauthenticated users hitting 401s are simply not authenticated — no error banner needed.

## Test plan

- [x] New unit test: `unauthorized handler is a no-op when there is no active user session`
- [x] All 32 unit tests pass
- [x] ESLint clean
- [ ] E2E: `leaderboard-unauth` test should pass again

Fixes the CI regression introduced by #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)