### PR TITLE
Fix: handle duplicate guess submission as 409 instead of 500

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
@@ -91,6 +91,11 @@ public class GameRepository(WordleTrackerSupremeDbContext dbContext) : IGameRepo
                 throw new DuplicatePuzzleAttemptException();
             }
 
+            if (await IsDuplicateGuessConflict(ex, cancellationToken))
+            {
+                throw new InvalidOperationException("A guess was already recorded for this slot. Refresh to see the current state.");
+            }
+
             throw;
         }
     }
@@ -119,6 +124,38 @@ public class GameRepository(WordleTrackerSupremeDbContext dbContext) : IGameRepo
                     cancellationToken);
 
             if (hasExistingAttempt)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> IsDuplicateGuessConflict(DbUpdateException ex, CancellationToken cancellationToken)
+    {
+        var pendingGuesses = ex.Entries
+            .Select(entry => entry.Entity)
+            .OfType<GuessAttempt>()
+            .Where(g => g.PlayerPuzzleAttemptId != Guid.Empty && g.GuessNumber > 0)
+            .ToList();
+
+        if (pendingGuesses.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var guess in pendingGuesses)
+        {
+            var hasExistingGuess = await dbContext.Guesses
+                .AsNoTracking()
+                .AnyAsync(
+                    existing => existing.Id != guess.Id &&
+                                existing.PlayerPuzzleAttemptId == guess.PlayerPuzzleAttemptId &&
+                                existing.GuessNumber == guess.GuessNumber,
+                    cancellationToken);
+
+            if (hasExistingGuess)
             {
                 return true;
             }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
@@ -1,14 +1,17 @@
 using System.Security.Claims;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Wordle.TrackerSupreme.Api.Auth;
 using Wordle.TrackerSupreme.Api.Controllers;
 using Wordle.TrackerSupreme.Api.Models.Auth;
 using Wordle.TrackerSupreme.Domain.Models;
 using Wordle.TrackerSupreme.Domain.Repositories;
+using Wordle.TrackerSupreme.Tests.Fakes;
 using Xunit;
 
 namespace Wordle.TrackerSupreme.Tests;
@@ -32,10 +35,13 @@ public class AuthControllerTests
             ExpiryMinutes = 60
         });
 
+        var env = new FakeWebHostEnvironment();
+
         var controller = new AuthController(
             repository,
             new JwtTokenService(jwtSettings),
-            new PasswordHasher<Player>())
+            new PasswordHasher<Player>(),
+            env)
         {
             ControllerContext = new ControllerContext
             {

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeWebHostEnvironment.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeWebHostEnvironment.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+
+namespace Wordle.TrackerSupreme.Tests.Fakes;
+
+public class FakeWebHostEnvironment : IWebHostEnvironment
+{
+    public string WebRootPath { get; set; } = string.Empty;
+    public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    public string ApplicationName { get; set; } = "Test";
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    public string ContentRootPath { get; set; } = string.Empty;
+    public string EnvironmentName { get; set; } = "Development";
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
@@ -71,4 +71,63 @@ public class GameRepositoryTests
         await act.Should().ThrowAsync<DuplicatePuzzleAttemptException>()
             .WithMessage("You already have an attempt for today's puzzle. Refresh to continue.");
     }
+
+    [Fact]
+    public async Task SaveChanges_translates_duplicate_guess_unique_index_violation()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var attemptId = Guid.NewGuid();
+
+        await using (var setupContext = new WordleTrackerSupremeDbContext(options))
+        {
+            await setupContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE Guesses (
+                    Id TEXT NOT NULL PRIMARY KEY,
+                    PlayerPuzzleAttemptId TEXT NOT NULL,
+                    GuessNumber INTEGER NOT NULL,
+                    GuessWord TEXT NOT NULL
+                );
+
+                CREATE UNIQUE INDEX IX_Guesses_PlayerPuzzleAttemptId_GuessNumber
+                    ON Guesses (PlayerPuzzleAttemptId, GuessNumber);
+                """);
+        }
+
+        await using (var seedContext = new WordleTrackerSupremeDbContext(options))
+        {
+            var existingId = Guid.NewGuid();
+            var guessWord = "CRANE";
+            await seedContext.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO Guesses (Id, PlayerPuzzleAttemptId, GuessNumber, GuessWord)
+                VALUES ({existingId}, {attemptId}, {1}, {guessWord});
+                """);
+        }
+
+        await using var duplicateContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new GameRepository(duplicateContext);
+        await repository.AddGuess(
+            new GuessAttempt
+            {
+                Id = Guid.NewGuid(),
+                PlayerPuzzleAttemptId = attemptId,
+                GuessNumber = 1,
+                GuessWord = "PLANT",
+                Feedback = []
+            },
+            [],
+            CancellationToken.None);
+
+        var act = async () => await repository.SaveChanges(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("A guess was already recorded for this slot. Refresh to see the current state.");
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `GameRepository.SaveChanges` to detect duplicate `GuessAttempt` unique-constraint violations and convert them to `InvalidOperationException` instead of letting a raw `DbUpdateException` bubble up as a 500 error
- The controller's existing `catch (InvalidOperationException)` handler returns 409 Conflict with the friendly message
- Adds `FakeWebHostEnvironment` stub to fix `AuthControllerTests` compilation broken when `IWebHostEnvironment` was added to `AuthController` on `main`
- Adds xUnit test using SQLite in-memory to verify the exact failure path (same pattern as the existing duplicate-attempt test)

## Test plan

- [x] All 67 backend xUnit tests pass
- [x] New `SaveChanges_translates_duplicate_guess_unique_index_violation` test covers the fixed path
- [x] CI runs full E2E suite on push

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)