### PR TITLE
[codex] Add today's leaderboard tab

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
@@ -115,6 +115,53 @@ public class StatsController(
         return Ok(leaderboard);
     }
 
+    [HttpGet("leaderboard/today")]
+    public async Task<ActionResult<IReadOnlyList<TodayLeaderboardEntryResponse>>> GetTodayLeaderboard(CancellationToken cancellationToken)
+    {
+        var today = gameClock.Today;
+        var players = await playerRepository.GetPlayersWithAttempts(cancellationToken);
+        var ranked = players
+            .Select(player => player.Attempts
+                .Where(attempt => attempt.DailyPuzzle?.PuzzleDate == today)
+                .OrderByDescending(attempt => attempt.CreatedOn)
+                .FirstOrDefault())
+            .Where(attempt => attempt is not null)
+            .Select(attempt => attempt!)
+            .OrderBy(attempt => attempt.Status switch
+            {
+                AttemptStatus.Solved => 0,
+                AttemptStatus.Failed => 1,
+                _ => 2
+            })
+            .ThenBy(attempt => attempt.Status == AttemptStatus.InProgress ? int.MaxValue : attempt.GuessCount ?? int.MaxValue)
+            .ThenBy(attempt => attempt.CompletedOn ?? DateTime.MaxValue)
+            .ThenByDescending(attempt => attempt.Status == AttemptStatus.InProgress ? attempt.GuessCount ?? 0 : 0)
+            .ThenBy(attempt => attempt.Player.DisplayName)
+            .ToList();
+
+        var leaderboard = new List<TodayLeaderboardEntryResponse>();
+        var rank = 1;
+
+        foreach (var attempt in ranked)
+        {
+            leaderboard.Add(new TodayLeaderboardEntryResponse(
+                rank,
+                attempt.PlayerId,
+                attempt.Player.DisplayName,
+                attempt.Status switch
+                {
+                    AttemptStatus.Solved => "Solved",
+                    AttemptStatus.Failed => "Failed",
+                    _ => "In progress"
+                },
+                attempt.GuessCount ?? 0,
+                attempt.PlayedInHardMode));
+            rank += 1;
+        }
+
+        return Ok(leaderboard);
+    }
+
     private static PlayerStatsResponse MapStats(PlayerStatistics stats)
     {
         return new PlayerStatsResponse(

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/TodayLeaderboardEntryResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/TodayLeaderboardEntryResponse.cs
@@ -1,0 +1,9 @@
+namespace Wordle.TrackerSupreme.Api.Models.Game;
+
+public record TodayLeaderboardEntryResponse(
+    int Rank,
+    Guid PlayerId,
+    string DisplayName,
+    string Result,
+    int GuessCount,
+    bool PlayedInHardMode);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Seeder/SeedDataGenerator.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Seeder/SeedDataGenerator.cs
@@ -177,7 +177,7 @@ public class SeedDataGenerator(
             return;
         }
 
-        var featuredCount = Math.Min(3, players.Count);
+        var featuredCount = Math.Min(4, players.Count);
 
         for (int index = 0; index < featuredCount; index++)
         {
@@ -216,11 +216,11 @@ public class SeedDataGenerator(
                 attempt = BuildFeaturedAttempt(
                     player,
                     puzzle,
-                    AttemptStatus.Solved,
-                    playedInHardMode: false,
-                    createdOn: puzzle.PuzzleDate.ToDateTime(new TimeOnly(15, 20)),
-                    completedOn: puzzle.PuzzleDate.ToDateTime(new TimeOnly(15, 45)),
-                    guessCount: 4);
+                    index == 2 ? AttemptStatus.Solved : AttemptStatus.InProgress,
+                    playedInHardMode: index != 2,
+                    createdOn: puzzle.PuzzleDate.ToDateTime(index == 2 ? new TimeOnly(15, 20) : new TimeOnly(11, 10)),
+                    completedOn: puzzle.PuzzleDate.ToDateTime(index == 2 ? new TimeOnly(15, 45) : new TimeOnly(11, 10)),
+                    guessCount: index == 2 ? 4 : Math.Max(2, _gameOptions.MaxGuesses - 2));
             }
 
             attempts.Add(attempt);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeederRunnerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeederRunnerTests.cs
@@ -50,7 +50,7 @@ public class SeederRunnerTests
         var totalPlayers = options.PlayerCount + 1;
         dbContext.Players.Should().HaveCount(totalPlayers);
         dbContext.DailyPuzzles.Should().HaveCount(options.PuzzleDays);
-        var featuredCount = Math.Min(3, totalPlayers);
+        var featuredCount = Math.Min(4, totalPlayers);
         dbContext.Attempts.Should().HaveCount(totalPlayers * 5 + featuredCount);
 
         var attempts = await dbContext.Attempts
@@ -128,7 +128,7 @@ public class SeederRunnerTests
         }
 
         var totalPlayers = options.PlayerCount + 1;
-        var featuredCount = Math.Min(3, totalPlayers);
+        var featuredCount = Math.Min(4, totalPlayers);
         var expectedPerPlayer = Math.Min(
             options.PuzzleDays,
             options.MinSolvedPuzzles + options.FailedPuzzlesMin + options.InProgressPuzzlesMin);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
@@ -113,6 +113,67 @@ public class StatsControllerTests
         payload.Single().DisplayName.Should().Be("Active");
     }
 
+    [Fact]
+    public async Task GetTodayLeaderboard_orders_solved_then_failed_then_in_progress_for_current_puzzle()
+    {
+        var anchorDate = new DateOnly(2025, 1, 2);
+
+        var speedy = CreatePlayer("Speedy");
+        speedy.Attempts.Add(CreateAttempt(speedy, anchorDate, AttemptStatus.Solved, true, 2));
+
+        var steady = CreatePlayer("Steady");
+        steady.Attempts.Add(CreateAttempt(steady, anchorDate, AttemptStatus.Solved, false, 3));
+
+        var unlucky = CreatePlayer("Unlucky");
+        unlucky.Attempts.Add(CreateAttempt(unlucky, anchorDate, AttemptStatus.Failed, true, 6));
+
+        var stillPlaying = CreatePlayer("StillPlaying");
+        stillPlaying.Attempts.Add(CreateAttempt(stillPlaying, anchorDate, AttemptStatus.InProgress, true, 4));
+
+        var yesterday = CreatePlayer("Yesterday");
+        yesterday.Attempts.Add(CreateAttempt(yesterday, anchorDate.AddDays(-1), AttemptStatus.Solved, true, 1));
+
+        var repo = new FakePlayerRepository([speedy, steady, unlucky, stillPlaying, yesterday]);
+        var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(anchorDate));
+
+        var result = await controller.GetTodayLeaderboard(CancellationToken.None);
+        var okResult = result.Result as OkObjectResult;
+
+        okResult.Should().NotBeNull();
+        var payload = okResult!.Value.Should().BeAssignableTo<IReadOnlyList<TodayLeaderboardEntryResponse>>().Subject;
+
+        payload.Select(entry => entry.DisplayName).Should().Equal("Speedy", "Steady", "Unlucky", "StillPlaying");
+        payload.Select(entry => entry.Rank).Should().Equal(1, 2, 3, 4);
+        payload.Select(entry => entry.Result).Should().Equal("Solved", "Solved", "Failed", "In progress");
+        payload.Select(entry => entry.GuessCount).Should().Equal(2, 3, 6, 4);
+        payload.Select(entry => entry.PlayedInHardMode).Should().Equal(true, false, true, true);
+    }
+
+    [Fact]
+    public async Task GetTodayLeaderboard_excludes_players_without_a_current_puzzle_attempt()
+    {
+        var anchorDate = new DateOnly(2025, 1, 2);
+
+        var idle = CreatePlayer("Idle");
+        var yesterday = CreatePlayer("Yesterday");
+        yesterday.Attempts.Add(CreateAttempt(yesterday, anchorDate.AddDays(-1), AttemptStatus.Solved, true, 2));
+
+        var active = CreatePlayer("Active");
+        active.Attempts.Add(CreateAttempt(active, anchorDate, AttemptStatus.InProgress, false, 1));
+
+        var repo = new FakePlayerRepository([idle, yesterday, active]);
+        var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(anchorDate));
+
+        var result = await controller.GetTodayLeaderboard(CancellationToken.None);
+        var okResult = result.Result as OkObjectResult;
+
+        okResult.Should().NotBeNull();
+        var payload = okResult!.Value.Should().BeAssignableTo<IReadOnlyList<TodayLeaderboardEntryResponse>>().Subject;
+
+        payload.Should().ContainSingle();
+        payload.Single().DisplayName.Should().Be("Active");
+    }
+
     private static Player CreatePlayer(string name)
     {
         return new Player

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -674,6 +674,42 @@
 				}
 			}
 		},
+		"/api/stats/leaderboard/today": {
+			"get": {
+				"tags": ["Stats"],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/plain": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/TodayLeaderboardEntryResponse"
+									}
+								}
+							},
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/TodayLeaderboardEntryResponse"
+									}
+								}
+							},
+							"text/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/TodayLeaderboardEntryResponse"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/api/Status": {
 			"get": {
 				"tags": ["Status"],
@@ -1185,6 +1221,33 @@
 						"items": {
 							"$ref": "#/components/schemas/SolutionEntryResponse"
 						}
+					}
+				},
+				"additionalProperties": false
+			},
+			"TodayLeaderboardEntryResponse": {
+				"type": "object",
+				"properties": {
+					"rank": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"playerId": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"displayName": {
+						"type": "string"
+					},
+					"result": {
+						"type": "string"
+					},
+					"guessCount": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"playedInHardMode": {
+						"type": "boolean"
 					}
 				},
 				"additionalProperties": false

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
@@ -29,6 +29,7 @@ export type { SignUpRequest } from './models/SignUpRequest';
 export type { SolutionEntryResponse } from './models/SolutionEntryResponse';
 export type { SolutionsResponse } from './models/SolutionsResponse';
 export type { SubmitGuessRequest } from './models/SubmitGuessRequest';
+export type { TodayLeaderboardEntryResponse } from './models/TodayLeaderboardEntryResponse';
 
 export { AdminService } from './services/AdminService';
 export { AuthService } from './services/AuthService';

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/TodayLeaderboardEntryResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/TodayLeaderboardEntryResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type TodayLeaderboardEntryResponse = {
+	rank?: number;
+	playerId?: string;
+	displayName?: string;
+	result?: string;
+	guessCount?: number;
+	playedInHardMode?: boolean;
+};

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
@@ -6,6 +6,7 @@ import type { LeaderboardEntryResponse } from '../models/LeaderboardEntryRespons
 import type { PlayerStatsEntryResponse } from '../models/PlayerStatsEntryResponse';
 import type { PlayerStatsFilterRequest } from '../models/PlayerStatsFilterRequest';
 import type { PlayerStatsResponse } from '../models/PlayerStatsResponse';
+import type { TodayLeaderboardEntryResponse } from '../models/TodayLeaderboardEntryResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -44,6 +45,18 @@ export class StatsService {
 		return __request(OpenAPI, {
 			method: 'GET',
 			url: '/api/stats/leaderboard'
+		});
+	}
+	/**
+	 * @returns TodayLeaderboardEntryResponse OK
+	 * @throws ApiError
+	 */
+	public static getApiStatsLeaderboardToday(): CancelablePromise<
+		Array<TodayLeaderboardEntryResponse>
+	> {
+		return __request(OpenAPI, {
+			method: 'GET',
+			url: '/api/stats/leaderboard/today'
 		});
 	}
 }

--- a/src/Wordle.TrackerSupreme.Web/src/lib/stats/leaderboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/stats/leaderboard.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatTodayLeaderboardMeta } from './leaderboard';
+
+describe('leaderboard helpers', () => {
+	it('formats today rows for finished and in-progress attempts', () => {
+		expect(
+			formatTodayLeaderboardMeta({
+				result: 'Solved',
+				guessCount: 3,
+				playedInHardMode: true
+			})
+		).toBe('3 guesses • Hard mode');
+
+		expect(
+			formatTodayLeaderboardMeta({
+				result: 'In progress',
+				guessCount: 4,
+				playedInHardMode: false
+			})
+		).toBe('4 guesses so far • Easy mode');
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/stats/leaderboard.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/stats/leaderboard.ts
@@ -1,0 +1,15 @@
+export type TodayLeaderboardEntryLike = {
+	result?: string | null;
+	guessCount?: number | null;
+	playedInHardMode?: boolean | null;
+};
+
+export function formatTodayLeaderboardMeta(entry: TodayLeaderboardEntryLike): string {
+	const guessCount = entry.guessCount ?? 0;
+	const guessLabel =
+		entry.result === 'In progress'
+			? `${guessCount} ${guessCount === 1 ? 'guess' : 'guesses'} so far`
+			: `${guessCount} ${guessCount === 1 ? 'guess' : 'guesses'}`;
+	const modeLabel = entry.playedInHardMode ? 'Hard mode' : 'Easy mode';
+	return `${guessLabel} • ${modeLabel}`;
+}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
@@ -4,11 +4,42 @@
 	import { auth } from '$lib/auth/store';
 	import { StatsService } from '$lib/api-client/services/StatsService';
 	import type { LeaderboardEntryResponse } from '$lib/api-client/models/LeaderboardEntryResponse';
+	import type { TodayLeaderboardEntryResponse } from '$lib/api-client/models/TodayLeaderboardEntryResponse';
+	import { formatTodayLeaderboardMeta } from '$lib/stats/leaderboard';
+
+	type LeaderboardTab = 'all-time' | 'today';
+
+	type LeaderboardTabContent = {
+		title: string;
+		description: string;
+		emptyState: string;
+	};
+
+	const tabContent: Record<LeaderboardTab, LeaderboardTabContent> = {
+		'all-time': {
+			title: 'Hard mode before noon',
+			description:
+				'Ranked by win rate, then average guesses, across hard-mode attempts submitted before the daily reveal.',
+			emptyState: 'No leaderboard entries yet. Solve today’s puzzle to claim the top spot.'
+		},
+		today: {
+			title: "Today's puzzle",
+			description:
+				'See who has finished today’s puzzle, how many guesses it took, and who is still playing right now.',
+			emptyState: 'No one has submitted an attempt for today’s puzzle yet.'
+		}
+	};
 
 	let loading = $state(false);
 	let error = $state<string | null>(null);
-	let entries = $state<LeaderboardEntryResponse[]>([]);
+	let allTimeEntries = $state<LeaderboardEntryResponse[]>([]);
+	let todayEntries = $state<TodayLeaderboardEntryResponse[]>([]);
 	let hasLoaded = $state(false);
+	let activeTab = $state<LeaderboardTab>('all-time');
+	let loadedTabs = $state<Record<LeaderboardTab, boolean>>({
+		'all-time': false,
+		today: false
+	});
 
 	function formatAverage(value: number | null | undefined) {
 		if (value === null || value === undefined) {
@@ -24,14 +55,33 @@
 		return `${Math.round(value * 100)}%`;
 	}
 
-	async function loadLeaderboard() {
+	function getTabContent(tab: LeaderboardTab): LeaderboardTabContent {
+		return tabContent[tab];
+	}
+
+	function getTodayResultClasses(result: string | null | undefined) {
+		if (result === 'Solved') {
+			return 'bg-emerald-400/15 text-emerald-200 ring-1 ring-emerald-300/20';
+		}
+		if (result === 'Failed') {
+			return 'bg-rose-500/15 text-rose-100 ring-1 ring-rose-300/20';
+		}
+		return 'bg-amber-400/15 text-amber-100 ring-1 ring-amber-300/20';
+	}
+
+	async function loadLeaderboard(tab: LeaderboardTab) {
 		if (!$auth.user) {
 			return;
 		}
 		loading = true;
 		error = null;
 		try {
-			entries = await StatsService.getApiStatsLeaderboard();
+			if (tab === 'all-time') {
+				allTimeEntries = await StatsService.getApiStatsLeaderboard();
+			} else {
+				todayEntries = await StatsService.getApiStatsLeaderboardToday();
+			}
+			loadedTabs[tab] = true;
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Unable to load leaderboard.';
 		} finally {
@@ -39,22 +89,36 @@
 		}
 	}
 
+	async function selectTab(tab: LeaderboardTab) {
+		activeTab = tab;
+		if (!$auth.user || loadedTabs[tab]) {
+			return;
+		}
+		await loadLeaderboard(tab);
+	}
+
 	onMount(() => {
 		if ($auth.user) {
 			hasLoaded = true;
-			void loadLeaderboard();
+			void loadLeaderboard(activeTab);
 		}
 	});
 
 	$effect(() => {
 		if ($auth.user && !hasLoaded) {
 			hasLoaded = true;
-			void loadLeaderboard();
+			void loadLeaderboard(activeTab);
 		}
 
 		if (!$auth.user && hasLoaded) {
 			hasLoaded = false;
-			entries = [];
+			allTimeEntries = [];
+			todayEntries = [];
+			activeTab = 'all-time';
+			loadedTabs = {
+				'all-time': false,
+				today: false
+			};
 		}
 	});
 </script>
@@ -80,11 +144,39 @@
 			class="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-2xl"
 		>
 			<p class="text-sm tracking-[0.2em] text-emerald-200/80 uppercase">Leaderboard</p>
-			<h1 class="mt-3 text-3xl font-semibold text-white">Hard mode before noon</h1>
-			<p class="mt-2 max-w-2xl text-sm text-slate-200/80">
-				Ranked by win rate, then average guesses, across hard-mode attempts submitted before the
-				daily reveal.
-			</p>
+			<div
+				class="mt-5 inline-flex rounded-full border border-white/10 bg-black/25 p-1"
+				role="tablist"
+			>
+				<button
+					type="button"
+					role="tab"
+					class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+						activeTab === 'all-time'
+							? 'bg-emerald-400 text-slate-950'
+							: 'text-slate-200/70 hover:text-white'
+					}`}
+					aria-selected={activeTab === 'all-time'}
+					on:click={() => void selectTab('all-time')}
+				>
+					All-time
+				</button>
+				<button
+					type="button"
+					role="tab"
+					class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+						activeTab === 'today'
+							? 'bg-emerald-400 text-slate-950'
+							: 'text-slate-200/70 hover:text-white'
+					}`}
+					aria-selected={activeTab === 'today'}
+					on:click={() => void selectTab('today')}
+				>
+					Today's puzzle
+				</button>
+			</div>
+			<h1 class="mt-4 text-3xl font-semibold text-white">{getTabContent(activeTab).title}</h1>
+			<p class="mt-2 max-w-2xl text-sm text-slate-200/80">{getTabContent(activeTab).description}</p>
 		</section>
 
 		{#if error}
@@ -99,11 +191,15 @@
 			<div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/70">
 				Loading leaderboard...
 			</div>
-		{:else if entries.length === 0}
+		{:else if activeTab === 'all-time' && allTimeEntries.length === 0}
 			<div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/70">
-				No leaderboard entries yet. Solve today’s puzzle to claim the top spot.
+				{getTabContent(activeTab).emptyState}
 			</div>
-		{:else}
+		{:else if activeTab === 'today' && todayEntries.length === 0}
+			<div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/70">
+				{getTabContent(activeTab).emptyState}
+			</div>
+		{:else if activeTab === 'all-time'}
 			<div class="overflow-hidden rounded-3xl border border-white/10 bg-black/30 shadow-xl">
 				<table class="w-full text-left text-sm text-slate-200/80" data-testid="leaderboard-table">
 					<thead class="bg-white/5 text-xs tracking-[0.2em] text-slate-200/70 uppercase">
@@ -118,7 +214,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each entries as entry (entry.playerId)}
+						{#each allTimeEntries as entry (entry.playerId)}
 							<tr class="border-t border-white/5" data-testid="leaderboard-row">
 								<td class="px-6 py-4 text-base font-semibold text-white">{entry.rank}</td>
 								<td class="px-6 py-4">
@@ -132,6 +228,39 @@
 								<td class="px-6 py-4">{entry.wins}</td>
 								<td class="px-6 py-4">{entry.totalAttempts}</td>
 								<td class="px-6 py-4">{entry.currentStreak}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<div class="overflow-hidden rounded-3xl border border-white/10 bg-black/30 shadow-xl">
+				<table class="w-full text-left text-sm text-slate-200/80" data-testid="leaderboard-table">
+					<thead class="bg-white/5 text-xs tracking-[0.2em] text-slate-200/70 uppercase">
+						<tr>
+							<th class="px-6 py-4">Rank</th>
+							<th class="px-6 py-4">Player</th>
+							<th class="px-6 py-4">Result</th>
+							<th class="px-6 py-4">Details</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each todayEntries as entry (entry.playerId)}
+							<tr class="border-t border-white/5" data-testid="leaderboard-row">
+								<td class="px-6 py-4 text-base font-semibold text-white">{entry.rank}</td>
+								<td class="px-6 py-4">
+									<div class="text-base font-semibold text-white">{entry.displayName}</div>
+								</td>
+								<td class="px-6 py-4">
+									<span
+										class={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${getTodayResultClasses(entry.result)}`}
+									>
+										{entry.result}
+									</span>
+								</td>
+								<td class="px-6 py-4 text-slate-100">
+									{formatTodayLeaderboardMeta(entry)}
+								</td>
 							</tr>
 						{/each}
 					</tbody>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/leaderboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/leaderboard.spec.ts
@@ -15,4 +15,11 @@ test('leaderboard renders seeded entries for signed-in users', async ({ page }) 
 	await expect(page.getByRole('heading', { name: 'Hard mode before noon' })).toBeVisible();
 	await expect(page.getByTestId('leaderboard-table')).toBeVisible();
 	await expect(page.getByTestId('leaderboard-row').first()).toBeVisible();
+
+	await page.getByRole('tab', { name: "Today's puzzle" }).click();
+
+	await expect(page.getByRole('heading', { name: "Today's puzzle" })).toBeVisible();
+	await expect(page.getByTestId('leaderboard-table')).toBeVisible();
+	await expect(page.getByText('Solved').first()).toBeVisible();
+	await expect(page.getByText('In progress').first()).toBeVisible();
 });

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-today.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-today.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+test('leaderboard can switch from all-time rankings to today standings', async ({ page }) => {
+	let allTimeRequests = 0;
+	let todayRequests = 0;
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/stats/leaderboard', async (route) => {
+		allTimeRequests += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify([
+				{
+					rank: 1,
+					playerId: '22222222-2222-2222-2222-222222222222',
+					displayName: 'Rival',
+					totalAttempts: 5,
+					wins: 4,
+					failures: 1,
+					currentStreak: 4,
+					longestStreak: 5,
+					practiceAttempts: 0,
+					averageGuessCount: 3,
+					winRate: 0.8
+				}
+			])
+		});
+	});
+
+	await page.route('**/api/stats/leaderboard/today', async (route) => {
+		todayRequests += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify([
+				{
+					rank: 1,
+					playerId: '33333333-3333-3333-3333-333333333333',
+					displayName: 'Today Winner',
+					result: 'Solved',
+					guessCount: 3,
+					playedInHardMode: true
+				},
+				{
+					rank: 2,
+					playerId: '44444444-4444-4444-4444-444444444444',
+					displayName: 'Still Playing',
+					result: 'In progress',
+					guessCount: 4,
+					playedInHardMode: false
+				}
+			])
+		});
+	});
+
+	await page.goto('/leaderboard', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByRole('tab', { name: 'All-time' })).toHaveAttribute(
+		'aria-selected',
+		'true'
+	);
+	await expect(page.getByRole('cell', { name: 'Rival' })).toBeVisible();
+	expect(allTimeRequests).toBe(1);
+	expect(todayRequests).toBe(0);
+
+	await page.getByRole('tab', { name: "Today's puzzle" }).click();
+
+	await expect(page.getByRole('heading', { name: "Today's puzzle" })).toBeVisible();
+	await expect(page.getByRole('cell', { name: 'Today Winner' })).toBeVisible();
+	await expect(page.getByRole('cell', { name: 'Solved' })).toBeVisible();
+	await expect(page.getByText('4 guesses so far • Easy mode')).toBeVisible();
+	expect(todayRequests).toBe(1);
+});


### PR DESCRIPTION
## Summary

- add a today-scoped leaderboard API and DTO without changing the existing all-time leaderboard contract
- update the Svelte leaderboard page with all-time and today tabs, plus a small helper with frontend unit coverage for today-row copy
- extend seeded data and UI/E2E coverage so the today tab shows solved, failed, and in-progress states deterministically

## Validation

- `docker-compose --profile tests run --rm tests-backend -lc "dotnet nuget locals all --clear && dotnet test Wordle.TrackerSupreme.sln"`
- `cd src/Wordle.TrackerSupreme.Web && npm test -- --run`
- `cd src/Wordle.TrackerSupreme.Web && npx playwright test`
- `cd src/Wordle.TrackerSupreme.Web && npm run lint`

## Blockers

- `./scripts/e2e.sh` fails on this VM because the compose app stack does not come up cleanly: the `web` container exits with `139` (`Segmentation fault`) and the `api` container logs `MSB4166` during `dotnet watch` startup, so the backend health check never becomes ready.

Closes #45

🤖 Generated with Codex