### PR TITLE
[codex] Improve game board accessibility

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/accessibility.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/accessibility.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { describeTileForScreenReader } from './accessibility';
+
+describe('game accessibility helpers', () => {
+	it('describes empty and evaluated tiles for screen readers', () => {
+		expect(describeTileForScreenReader('', null)).toBe('Empty tile');
+		expect(describeTileForScreenReader('c', 'Correct')).toBe('C, correct');
+		expect(describeTileForScreenReader('r', 'Present')).toBe('R, present');
+		expect(describeTileForScreenReader('a', 'Absent')).toBe('A, absent');
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/accessibility.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/accessibility.ts
@@ -1,0 +1,17 @@
+import type { LetterResult } from './types';
+
+export function describeTileForScreenReader(
+	letter: string | null | undefined,
+	result: LetterResult | null
+): string {
+	const normalizedLetter = letter?.trim().toUpperCase() ?? '';
+	if (!normalizedLetter) {
+		return 'Empty tile';
+	}
+
+	if (result === null) {
+		return normalizedLetter;
+	}
+
+	return `${normalizedLetter}, ${result.toLowerCase()}`;
+}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 		fetchMyStats,
 		submitGuess
 	} from '$lib/game/api';
+	import { describeTileForScreenReader } from '$lib/game/accessibility';
 	import { getRevealDurationMs, shouldTriggerSolveCelebration } from '$lib/game/celebration';
 	import {
 		buildConfettiPieces,
@@ -39,6 +40,8 @@
 	let shakeTimer: ReturnType<typeof setTimeout> | null = null;
 	let countdownInterval: ReturnType<typeof setInterval> | null = null;
 	let countdown = '';
+	let announcement: string | null = null;
+	let announcementIsError = false;
 	const keyboardRows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
 	const confettiDurationMs = 1200;
 
@@ -99,6 +102,8 @@
 	}
 
 	$: guessInputLocked = !state || !state.canGuess || submitting;
+	$: announcement = error ?? message;
+	$: announcementIsError = error !== null;
 
 	async function loadEverything() {
 		await loadState();
@@ -451,12 +456,14 @@
 			{:else if state}
 				<div class="mt-6">
 					<div class="space-y-4 rounded-2xl border border-white/10 bg-black/20 p-6 shadow-inner">
-						<div class="grid grid-rows-6 gap-1.5">
+						<div class="grid grid-rows-6 gap-1.5" role="grid" aria-label="Wordle board">
 							{#each Array(state.maxGuesses).keys() as rowIndex (rowIndex)}
 								<div
 									class={`grid justify-center gap-1.5${shakingRow === rowIndex ? ' animate-shake' : ''}`}
 									style={`grid-template-columns: repeat(${state.wordLength}, 3.5rem);`}
 									data-testid={`board-row-${rowIndex}`}
+									role="row"
+									aria-label={`Guess row ${rowIndex + 1}`}
 								>
 									{#if state.attempt?.guesses[rowIndex]}
 										{#each state.attempt.guesses[rowIndex].feedback as fb (fb.position)}
@@ -466,6 +473,8 @@
 													state.attempt.guesses[rowIndex].guessId,
 													fb.position
 												)}
+												role="gridcell"
+												aria-label={describeTileForScreenReader(fb.letter, fb.result)}
 											>
 												{fb.letter}
 											</div>
@@ -473,9 +482,19 @@
 									{:else}
 										{#each Array(state.wordLength).keys() as col (col)}
 											{#if rowIndex === (state.attempt?.guesses.length ?? 0)}
-												<div class={tileClass(null)}>{(guess[col] ?? '').toUpperCase()}</div>
+												<div
+													class={tileClass(null)}
+													role="gridcell"
+													aria-label={describeTileForScreenReader(guess[col] ?? '', null)}
+												>
+													{(guess[col] ?? '').toUpperCase()}
+												</div>
 											{:else}
-												<div class={tileClass(null)}></div>
+												<div
+													class={tileClass(null)}
+													role="gridcell"
+													aria-label={describeTileForScreenReader('', null)}
+												></div>
 											{/if}
 										{/each}
 									{/if}
@@ -483,23 +502,19 @@
 							{/each}
 						</div>
 
-						{#if message}
+						{#if announcement}
 							<div
-								class={`rounded-xl border px-4 py-3 text-sm ${state?.attempt?.status === 'Failed' ? 'border-amber-300/40 bg-amber-400/10 text-amber-50' : 'border-emerald-300/40 bg-emerald-400/10 text-emerald-50'}`}
-								data-testid="completed-message"
+								class={`rounded-xl border px-4 py-3 text-sm ${announcementIsError ? 'border-rose-400/40 bg-rose-500/10 text-rose-50' : state?.attempt?.status === 'Failed' ? 'border-amber-300/40 bg-amber-400/10 text-amber-50' : 'border-emerald-300/40 bg-emerald-400/10 text-emerald-50'}`}
+								data-testid={announcementIsError ? 'error-message' : 'completed-message'}
+								role="status"
+								aria-live="polite"
+								aria-atomic="true"
 							>
-								{message}
-							</div>
-						{/if}
-						{#if error}
-							<div
-								class="rounded-xl border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-50"
-							>
-								{error}
+								{announcement}
 							</div>
 						{/if}
 
-						<div class="space-y-3 pt-3">
+						<div class="space-y-3 pt-3" role="group" aria-label="On-screen keyboard">
 							{#each keyboardRows as row, rowIndex (rowIndex)}
 								<div class="flex items-center justify-center gap-2">
 									{#if rowIndex === 2}
@@ -508,6 +523,7 @@
 											onclick={removeLetter}
 											disabled={guessInputLocked}
 											data-testid="remove-letter"
+											aria-label="Remove letter"
 										>
 											Back
 										</button>
@@ -528,6 +544,7 @@
 											onclick={submitFromKeyboard}
 											disabled={guessInputLocked}
 											data-testid="submit-guess"
+											aria-label="Submit guess"
 										>
 											Enter
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/game-accessibility.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/game-accessibility.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+test('game board exposes accessible grid semantics and live feedback', async ({ page }) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: true,
+				solutionRevealed: true,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: false,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'Solved',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: '2025-01-01T00:05:00Z',
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Correct' },
+								{ position: 1, letter: 'R', result: 'Correct' },
+								{ position: 2, letter: 'A', result: 'Correct' },
+								{ position: 3, letter: 'N', result: 'Correct' },
+								{ position: 4, letter: 'E', result: 'Correct' }
+							]
+						}
+					]
+				},
+				solution: 'CRANE'
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByRole('grid', { name: 'Wordle board' })).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Remove letter' })).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Submit guess' })).toBeVisible();
+
+	const status = page.getByRole('status');
+	await expect(status).toBeVisible();
+	await expect(status).toContainText('You solved it in 1 guess');
+});


### PR DESCRIPTION
## Summary

- add semantic grid and gridcell roles plus screen-reader labels for the Wordle board tiles
- expose the completed/error announcement area as a polite live region and give the on-screen action keys explicit labels
- cover the new behavior with a small accessibility helper unit test and a Playwright UI regression for the game page

## Validation

- `cd src/Wordle.TrackerSupreme.Web && npm test -- --run`
- `cd src/Wordle.TrackerSupreme.Web && npx playwright test`
- `cd src/Wordle.TrackerSupreme.Web && npm run lint`
- `./scripts/e2e.sh` via a temporary `docker compose` -> `docker-compose` compatibility shim

## Blockers

- The repo-mandated `./scripts/e2e.sh` flow still fails in this VM after the stack starts because the database never gets initialized under the `docker-compose` shim; signup/admin flows fail with `Postgres 42P01: relation "Players" does not exist` in `artifacts/e2e/backend.log`.

Closes #44

🤖 Generated with Codex
