### PR TITLE
[codex] Fix auth input lock after sign out

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 		type ConfettiPiece
 	} from '$lib/game/confetti';
 	import type { GameStateResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
-	import { onDestroy, onMount, tick } from 'svelte';
+	import { onMount, tick } from 'svelte';
 
 	let checking = true;
 	let loadingState = true;
@@ -84,12 +84,11 @@
 		};
 
 		window.addEventListener('keydown', keyHandler);
-
-		onDestroy(() => {
+		return () => {
 			window.removeEventListener('keydown', keyHandler);
 			stopCountdown();
 			unsubscribe();
-		});
+		};
 	});
 
 	$: {

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/auth-flow.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/auth-flow.spec.ts
@@ -16,8 +16,16 @@ test('user can sign up, sign out, and sign back in', async ({ page }) => {
 	await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
 
 	await page.goto('/signin');
-	await page.getByLabel('Email').fill(credentials.email);
-	await page.getByLabel('Password').fill(credentials.password);
+	const emailInput = page.getByLabel('Email');
+	await emailInput.click();
+	await emailInput.pressSequentially(credentials.email);
+	await expect(emailInput).toHaveValue(credentials.email);
+
+	const passwordInput = page.getByLabel('Password');
+	await passwordInput.click();
+	await passwordInput.pressSequentially(credentials.password);
+	await expect(passwordInput).toHaveValue(credentials.password);
+
 	await page.getByRole('button', { name: 'Sign in' }).click();
 	await page.waitForURL('**/');
 

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/signin.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/signin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('sign-in form shows validation and handles failed auth', async ({ page }) => {
 	await page.route('**/api/Auth/me', async (route) => {
@@ -28,4 +28,75 @@ test('sign-in form shows validation and handles failed auth', async ({ page }) =
 	const errorBox = page.locator('form .rounded-xl');
 	await expect(errorBox).toBeVisible();
 	await expect(errorBox).not.toHaveText('');
+});
+
+test('sign-in fields remain editable after signing out from the game page', async ({ page }) => {
+	let authMeCalls = 0;
+
+	await page.route('**/api/Auth/me', async (route) => {
+		authMeCalls += 1;
+
+		if (authMeCalls === 1) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					id: '11111111-1111-1111-1111-111111111111',
+					displayName: 'Tester',
+					email: 'tester@example.com',
+					createdOn: '2025-01-01T00:00:00Z',
+					isAdmin: false
+				})
+			});
+			return;
+		}
+
+		await route.fulfill({
+			status: 401,
+			contentType: 'application/json',
+			body: JSON.stringify({ message: 'Unauthorized' })
+		});
+	});
+
+	await page.route('**/api/auth/signout', async (route) => {
+		await route.fulfill({ status: 204, body: '' });
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: false,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: false,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: []
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+
+	await page.getByRole('button', { name: 'Sign out' }).click();
+	await page.waitForURL('**/signin');
+
+	const emailInput = page.getByLabel('Email');
+	await emailInput.click();
+	await emailInput.pressSequentially('player@example.com');
+
+	await expect(emailInput).toHaveValue('player@example.com');
 });


### PR DESCRIPTION
## Summary

- fix the game page cleanup so its global `keydown` listener is removed when navigating away
- add a UI regression that reproduces the logout -> sign-in typing lock with real keystrokes
- strengthen the auth E2E flow to type into the post-logout sign-in form instead of bypassing the keyboard path

## Root Cause

The game page registered a global `window.keydown` handler inside `onMount`, but it attempted to clean that up via `onDestroy(...)` nested inside the mount callback. That cleanup never ran on navigation, so the stale Wordle handler kept calling `preventDefault()` on letter keys after sign-out and blocked typing in `/signin` and `/signup`.

## Validation

- `cd src/Wordle.TrackerSupreme.Web && npm test -- --run`
- `cd src/Wordle.TrackerSupreme.Web && npx playwright test --project=chromium`
- `cd src/Wordle.TrackerSupreme.Web && npx playwright test tests/ui/signin.spec.ts --project=chromium`
- `cd src/Wordle.TrackerSupreme.Web && npx prettier --check src tests playwright.config.ts playwright.e2e.config.ts vite.config.ts svelte.config.js eslint.config.js package.json`
- `cd src/Wordle.TrackerSupreme.Web && npx eslint src tests`
- `PATH="/tmp/codex-docker-shim:$PATH" ./scripts/e2e.sh` (reached the repo-wide E2E suite, then failed on unrelated existing `tests/e2e/admin.spec.ts` with `Internal Server Error` during admin sign-in)

Closes #75

🤖 Generated with Codex
