### PR TITLE
[codex] Polish keyboard highlights after guesses

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/keyboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/keyboard.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { GuessResponse } from './types';
+import { getKeyboardLetterState } from './keyboard';
+
+describe('getKeyboardLetterState', () => {
+	it('returns the strongest known result for a letter', () => {
+		const guesses: GuessResponse[] = [
+			{
+				guessId: 'guess-1',
+				guessNumber: 1,
+				guessWord: 'CRANE',
+				feedback: [
+					{ position: 0, letter: 'C', result: 'Absent' },
+					{ position: 1, letter: 'R', result: 'Present' },
+					{ position: 2, letter: 'A', result: 'Absent' },
+					{ position: 3, letter: 'N', result: 'Correct' },
+					{ position: 4, letter: 'E', result: 'Absent' }
+				]
+			},
+			{
+				guessId: 'guess-2',
+				guessNumber: 2,
+				guessWord: 'RINSE',
+				feedback: [
+					{ position: 0, letter: 'R', result: 'Correct' },
+					{ position: 1, letter: 'I', result: 'Absent' },
+					{ position: 2, letter: 'N', result: 'Correct' },
+					{ position: 3, letter: 'S', result: 'Absent' },
+					{ position: 4, letter: 'E', result: 'Present' }
+				]
+			}
+		];
+
+		expect(getKeyboardLetterState(guesses, 'R')).toBe('Correct');
+		expect(getKeyboardLetterState(guesses, 'E')).toBe('Present');
+		expect(getKeyboardLetterState(guesses, 'C')).toBe('Absent');
+		expect(getKeyboardLetterState(guesses, 'Z')).toBeNull();
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/keyboard.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/keyboard.ts
@@ -1,0 +1,32 @@
+import type { GuessResponse, LetterResult } from './types';
+
+export function getKeyboardLetterState(
+	guesses: GuessResponse[] | null | undefined,
+	letter: string
+): LetterResult | null {
+	if (!guesses?.length) {
+		return null;
+	}
+
+	let best: LetterResult | null = null;
+
+	for (const guess of guesses) {
+		for (const feedback of guess.feedback) {
+			if (feedback.letter !== letter) {
+				continue;
+			}
+
+			if (feedback.result === 'Correct') {
+				return 'Correct';
+			}
+
+			if (feedback.result === 'Present') {
+				best = 'Present';
+			} else if (best === null) {
+				best = 'Absent';
+			}
+		}
+	}
+
+	return best;
+}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 		defaultConfettiPieceCount,
 		type ConfettiPiece
 	} from '$lib/game/confetti';
+	import { getKeyboardLetterState } from '$lib/game/keyboard';
 	import type { GameStateResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
 	import { onDestroy, onMount, tick } from 'svelte';
 
@@ -278,32 +279,8 @@
 		return `animation-delay:${position * 220}ms`;
 	}
 
-	function keyState(letter: string): LetterResult | 'Used' | null {
-		if (!state?.attempt?.guesses?.length) {
-			return null;
-		}
-		let best: LetterResult | 'Used' | null = null;
-
-		for (const guessItem of state.attempt.guesses) {
-			for (const fb of guessItem.feedback) {
-				if (fb.letter !== letter) {
-					continue;
-				}
-				if (fb.result === 'Correct') {
-					return 'Correct';
-				}
-				if (fb.result === 'Present') {
-					best = 'Present';
-				} else if (!best) {
-					best = 'Used';
-				}
-			}
-			if (!best && guessItem.guessWord.includes(letter)) {
-				best = 'Used';
-			}
-		}
-
-		return best;
+	function keyState(letter: string): LetterResult | null {
+		return getKeyboardLetterState(state?.attempt?.guesses, letter);
 	}
 
 	function keyClass(letter: string) {
@@ -316,8 +293,8 @@
 		if (stateKey === 'Present') {
 			return `${base} border-amber-300/70 bg-amber-300 text-slate-900`;
 		}
-		if (stateKey === 'Used') {
-			return `${base} border-white/25 bg-white/50 text-slate-900`;
+		if (stateKey === 'Absent') {
+			return `${base} border-slate-500/70 bg-slate-600 text-slate-100`;
 		}
 		return `${base} border-white/60 bg-white/90 text-slate-900 shadow hover:border-white hover:bg-white`;
 	}
@@ -534,6 +511,7 @@
 											onclick={() => pushLetter(letter)}
 											disabled={guessInputLocked}
 											data-testid={`keyboard-key-${letter}`}
+											data-state={(keyState(letter) ?? 'unused').toLowerCase()}
 										>
 											{letter}
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/keyboard-highlights.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/keyboard-highlights.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+test('on-screen keyboard keeps Wordle-style highlights after evaluated guesses', async ({
+	page
+}) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Present' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Correct' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByTestId('board-row-0').waitFor({ state: 'visible' });
+
+	await expect(page.getByTestId('keyboard-key-C')).toHaveAttribute('data-state', 'absent');
+	await expect(page.getByTestId('keyboard-key-R')).toHaveAttribute('data-state', 'present');
+	await expect(page.getByTestId('keyboard-key-N')).toHaveAttribute('data-state', 'correct');
+	await expect(page.getByTestId('keyboard-key-Z')).toHaveAttribute('data-state', 'unused');
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/keyboard-highlights.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/keyboard-highlights.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+test('on-screen keyboard reflects absent, present, and correct letters from guesses', async ({
+	page
+}) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Present' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Correct' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('keyboard-key-C')).toHaveAttribute('data-state', 'absent');
+	await expect(page.getByTestId('keyboard-key-R')).toHaveAttribute('data-state', 'present');
+	await expect(page.getByTestId('keyboard-key-N')).toHaveAttribute('data-state', 'correct');
+	await expect(page.getByTestId('keyboard-key-Z')).toHaveAttribute('data-state', 'unused');
+});


### PR DESCRIPTION
## Summary

- align the on-screen keyboard with actual Wordle result states instead of the previous generic `Used` bucket
- make absent letters read as a clear gray state while keeping present/correct letters in yellow and green
- add unit, UI, and route-mocked E2E coverage for keyboard highlight precedence and DOM state markers

## Root Cause

The keyboard already tracked letters internally, but it collapsed absent letters into a vague `Used` state and styled them only slightly differently from untouched keys. That made the keyboard feel under-highlighted even after evaluated guesses and left the behavior effectively unverified.

## Validation

- `cd src/Wordle.TrackerSupreme.Web && npm test -- --run`
- `cd src/Wordle.TrackerSupreme.Web && npx playwright test tests/ui/keyboard-highlights.spec.ts --project=chromium`
- `cd src/Wordle.TrackerSupreme.Web && E2E_BASE_URL=http://localhost:3000 npx playwright test -c playwright.e2e.config.ts tests/e2e/keyboard-highlights.spec.ts --project=chromium`
- `cd src/Wordle.TrackerSupreme.Web && npx prettier --check src tests playwright.config.ts playwright.e2e.config.ts vite.config.ts svelte.config.js eslint.config.js package.json`
- `cd src/Wordle.TrackerSupreme.Web && npx eslint src tests`

## Blockers

- A full local `npx playwright test --project=chromium` sweep on this VM remains flaky because the Vite dev server intermittently segfaults during startup/restarts; the changed-path UI spec and deterministic E2E regression both passed, but unrelated UI specs started failing once the dev server crashed.

Closes #76

🤖 Generated with Codex
