### PR TITLE
Standardise API error responses to RFC 9457 ProblemDetails (#35)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Wordle.TrackerSupreme.Api.Models.Admin;
 using Wordle.TrackerSupreme.Api.Models.Game;
@@ -58,11 +59,11 @@ public class AdminController(IAdminService adminService) : ControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
         catch (ArgumentException ex)
         {
-            return BadRequest(new { message = ex.Message });
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
         }
     }
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -84,7 +84,7 @@ public class AdminController(IAdminService adminService) : ControllerBase
         }
         catch (ArgumentException ex)
         {
-            return BadRequest(new { message = ex.Message });
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
         }
     }
 
@@ -128,11 +128,11 @@ public class AdminController(IAdminService adminService) : ControllerBase
         }
         catch (ArgumentException ex)
         {
-            return BadRequest(new { message = ex.Message });
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
     }
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
@@ -29,12 +30,12 @@ public class AuthController(
 
         if (await playerRepository.IsDisplayNameTaken(displayName, null, cancellationToken))
         {
-            return Conflict(new { message = "Display name is already taken." });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = "Display name is already taken." });
         }
 
         if (await playerRepository.IsEmailTaken(email, null, cancellationToken))
         {
-            return Conflict(new { message = "Email is already registered." });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = "Email is already registered." });
         }
 
         var player = new Player
@@ -66,14 +67,14 @@ public class AuthController(
         if (player is null)
         {
             logger.LogWarning("Sign-in failed: email not found. Email={Email}", email);
-            return Unauthorized(new { message = "Invalid credentials." });
+            return Unauthorized(new ProblemDetails { Status = StatusCodes.Status401Unauthorized, Detail = "Invalid credentials." });
         }
 
         var verification = passwordHasher.VerifyHashedPassword(player, player.PasswordHash, request.Password);
         if (verification == PasswordVerificationResult.Failed)
         {
             logger.LogWarning("Sign-in failed: wrong password. PlayerId={PlayerId}", player.Id);
-            return Unauthorized(new { message = "Invalid credentials." });
+            return Unauthorized(new ProblemDetails { Status = StatusCodes.Status401Unauthorized, Detail = "Invalid credentials." });
         }
 
         logger.LogInformation("Player signed in. PlayerId={PlayerId}", player.Id);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
@@ -33,7 +33,7 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
+            return PuzzleUnavailable(ex.Message);
         }
     }
 
@@ -54,19 +54,19 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
+            return PuzzleUnavailable(ex.Message);
         }
         catch (ArgumentException ex)
         {
-            return BadRequest(new { message = ex.Message });
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
         }
         catch (DuplicatePuzzleAttemptException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
     }
 
@@ -87,15 +87,15 @@ public class GameController(
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
+            return PuzzleUnavailable(ex.Message);
         }
         catch (DuplicatePuzzleAttemptException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(new { message = ex.Message });
+            return Conflict(new ProblemDetails { Status = StatusCodes.Status409Conflict, Detail = ex.Message });
         }
     }
 
@@ -107,15 +107,27 @@ public class GameController(
             var snapshot = await gameplayService.GetSolutions(cancellationToken);
             if (!snapshot.CutoffPassed)
             {
-                return StatusCode(StatusCodes.Status403Forbidden, new { message = "Solutions unlock after 12:00 PM local time." });
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    new ProblemDetails { Status = StatusCodes.Status403Forbidden, Detail = "Solutions unlock after 12:00 PM local time." });
             }
 
             return Ok(MapSolutions(snapshot));
         }
         catch (DailyPuzzleUnavailableException ex)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { code = "puzzle_unavailable", message = ex.Message });
+            return PuzzleUnavailable(ex.Message);
         }
+    }
+
+    private ObjectResult PuzzleUnavailable(string detail)
+    {
+        var pd = new ProblemDetails
+        {
+            Status = StatusCodes.Status503ServiceUnavailable,
+            Detail = detail
+        };
+        pd.Extensions["code"] = "puzzle_unavailable";
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, pd);
     }
 
     private Guid? GetPlayerId()

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
@@ -80,7 +80,8 @@ public class GameControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Which;
         objectResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-        objectResult.Value.Should().BeEquivalentTo(new { message = "Unable to retrieve today's puzzle. Please try again later." });
+        var pd = objectResult.Value.Should().BeOfType<ProblemDetails>().Which;
+        pd.Detail.Should().Be("Unable to retrieve today's puzzle. Please try again later.");
     }
 
     [Fact]
@@ -126,10 +127,8 @@ public class GameControllerTests
             CancellationToken.None);
 
         var conflict = result.Result.Should().BeOfType<ConflictObjectResult>().Which;
-        conflict.Value.Should().BeEquivalentTo(new
-        {
-            message = "You already have an attempt for today's puzzle. Refresh to continue."
-        });
+        var pd = conflict.Value.Should().BeOfType<ProblemDetails>().Which;
+        pd.Detail.Should().Be("You already have an attempt for today's puzzle. Refresh to continue.");
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.Web/.prettierignore
+++ b/src/Wordle.TrackerSupreme.Web/.prettierignore
@@ -7,3 +7,4 @@ bun.lockb
 
 # Miscellaneous
 /static/
+test-results/

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -47,6 +47,16 @@
 								}
 							}
 						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			}
@@ -90,6 +100,16 @@
 							"text/json": {
 								"schema": {
 									"$ref": "#/components/schemas/AuthResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
 								}
 							}
 						}
@@ -249,6 +269,26 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			}
@@ -289,6 +329,26 @@
 				"responses": {
 					"204": {
 						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			}
@@ -343,6 +403,26 @@
 							"text/json": {
 								"schema": {
 									"$ref": "#/components/schemas/AdminPlayerDetailResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
 								}
 							}
 						}
@@ -403,6 +483,26 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			},
@@ -446,6 +546,16 @@
 							"text/json": {
 								"schema": {
 									"$ref": "#/components/schemas/GameStateResponse"
+								}
+							}
+						}
+					},
+					"503": {
+						"description": "Service Unavailable",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
 								}
 							}
 						}
@@ -495,6 +605,36 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"503": {
+						"description": "Service Unavailable",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			}
@@ -519,6 +659,26 @@
 							"text/json": {
 								"schema": {
 									"$ref": "#/components/schemas/GameStateResponse"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"503": {
+						"description": "Service Unavailable",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
 								}
 							}
 						}
@@ -551,7 +711,24 @@
 						}
 					},
 					"403": {
-						"description": "Forbidden"
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
+					},
+					"503": {
+						"description": "Service Unavailable",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemDetails"
+								}
+							}
+						}
 					}
 				}
 			}
@@ -1358,6 +1535,33 @@
 					}
 				},
 				"additionalProperties": false
+			},
+			"ProblemDetails": {
+				"type": "object",
+				"properties": {
+					"type": {
+						"type": "string",
+						"nullable": true
+					},
+					"title": {
+						"type": "string",
+						"nullable": true
+					},
+					"status": {
+						"type": "integer",
+						"format": "int32",
+						"nullable": true
+					},
+					"detail": {
+						"type": "string",
+						"nullable": true
+					},
+					"instance": {
+						"type": "string",
+						"nullable": true
+					}
+				},
+				"additionalProperties": {}
 			}
 		},
 		"securitySchemes": {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
@@ -25,6 +25,7 @@ export type { PlayerResponse } from './models/PlayerResponse';
 export type { PlayerStatsEntryResponse } from './models/PlayerStatsEntryResponse';
 export type { PlayerStatsFilterRequest } from './models/PlayerStatsFilterRequest';
 export type { PlayerStatsResponse } from './models/PlayerStatsResponse';
+export type { ProblemDetails } from './models/ProblemDetails';
 export type { SignInRequest } from './models/SignInRequest';
 export type { SignUpRequest } from './models/SignUpRequest';
 export type { SolutionEntryResponse } from './models/SolutionEntryResponse';

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/PlayerStatsResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/PlayerStatsResponse.ts
@@ -10,5 +10,5 @@ export type PlayerStatsResponse = {
 	currentStreak?: number;
 	longestStreak?: number;
 	averageGuessCount?: number | null;
-	guessDistribution?: Record<string, number>;
+	guessDistribution?: Record<string, number> | null;
 };

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/ProblemDetails.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/ProblemDetails.ts
@@ -1,0 +1,5 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProblemDetails = Record<string, any>;

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AdminService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AdminService.ts
@@ -58,7 +58,11 @@ export class AdminService {
 				playerId: playerId
 			},
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				400: `Bad Request`,
+				409: `Conflict`
+			}
 		});
 	}
 	/**
@@ -79,7 +83,11 @@ export class AdminService {
 				playerId: playerId
 			},
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				400: `Bad Request`,
+				409: `Conflict`
+			}
 		});
 	}
 	/**
@@ -100,7 +108,11 @@ export class AdminService {
 				playerId: playerId
 			},
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				400: `Bad Request`,
+				409: `Conflict`
+			}
 		});
 	}
 	/**
@@ -121,7 +133,11 @@ export class AdminService {
 				attemptId: attemptId
 			},
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				400: `Bad Request`,
+				409: `Conflict`
+			}
 		});
 	}
 	/**

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AuthService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AuthService.ts
@@ -23,7 +23,10 @@ export class AuthService {
 			method: 'POST',
 			url: '/api/Auth/signup',
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				409: `Conflict`
+			}
 		});
 	}
 	/**
@@ -39,7 +42,10 @@ export class AuthService {
 			method: 'POST',
 			url: '/api/Auth/signin',
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				401: `Unauthorized`
+			}
 		});
 	}
 	/**

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/GameService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/GameService.ts
@@ -16,7 +16,10 @@ export class GameService {
 	public static getApiGameState(): CancelablePromise<GameStateResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
-			url: '/api/game/state'
+			url: '/api/game/state',
+			errors: {
+				503: `Service Unavailable`
+			}
 		});
 	}
 	/**
@@ -32,7 +35,12 @@ export class GameService {
 			method: 'POST',
 			url: '/api/game/guess',
 			body: requestBody,
-			mediaType: 'application/json'
+			mediaType: 'application/json',
+			errors: {
+				400: `Bad Request`,
+				409: `Conflict`,
+				503: `Service Unavailable`
+			}
 		});
 	}
 	/**
@@ -42,7 +50,11 @@ export class GameService {
 	public static postApiGameEasyMode(): CancelablePromise<GameStateResponse> {
 		return __request(OpenAPI, {
 			method: 'POST',
-			url: '/api/game/easy-mode'
+			url: '/api/game/easy-mode',
+			errors: {
+				409: `Conflict`,
+				503: `Service Unavailable`
+			}
 		});
 	}
 	/**
@@ -54,7 +66,8 @@ export class GameService {
 			method: 'GET',
 			url: '/api/game/solutions',
 			errors: {
-				403: `Forbidden`
+				403: `Forbidden`,
+				503: `Service Unavailable`
 			}
 		});
 	}

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { LeaderboardEntryResponse } from '../models/LeaderboardEntryResponse';
 import type { LeaderboardPageResponse } from '../models/LeaderboardPageResponse';
 import type { PlayerStatsEntryResponse } from '../models/PlayerStatsEntryResponse';
 import type { PlayerStatsFilterRequest } from '../models/PlayerStatsFilterRequest';
@@ -43,18 +42,18 @@ export class StatsService {
 	 * @throws ApiError
 	 */
 	public static getApiStatsLeaderboard({
-		page,
-		pageSize
+		page = 1,
+		pageSize = 10
 	}: {
 		page?: number;
 		pageSize?: number;
-	} = {}): CancelablePromise<LeaderboardPageResponse> {
+	}): CancelablePromise<LeaderboardPageResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
 			url: '/api/stats/leaderboard',
 			query: {
-				page,
-				pageSize
+				page: page,
+				pageSize: pageSize
 			}
 		});
 	}

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -137,7 +137,9 @@ describe('api helpers', () => {
 
 		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
 
-		await expect(submitGuess('crane')).rejects.toThrowError('You already have an attempt for today.');
+		await expect(submitGuess('crane')).rejects.toThrowError(
+			'You already have an attempt for today.'
+		);
 	});
 
 	it('submits guesses with a JSON payload', async () => {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -93,6 +93,27 @@ describe('api helpers', () => {
 		expect((err as ApiResponseError).message).toBe('No puzzle today.');
 	});
 
+	it('throws error detail from ProblemDetails payload when request fails', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 409,
+			statusText: 'Conflict',
+			text: () =>
+				Promise.resolve(
+					JSON.stringify({
+						type: 'https://tools.ietf.org/html/rfc9110#section-15.5.10',
+						title: 'Conflict',
+						status: 409,
+						detail: 'You already have an attempt for today.'
+					})
+				)
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await expect(submitGuess('crane')).rejects.toThrowError('You already have an attempt for today.');
+	});
+
 	it('submits guesses with a JSON payload', async () => {
 		const mockResponse = {
 			ok: true,

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -93,6 +93,32 @@ describe('api helpers', () => {
 		expect((err as ApiResponseError).message).toBe('No puzzle today.');
 	});
 
+	it('reads detail from ProblemDetails 503 response when detail and code are both present', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+			text: () =>
+				Promise.resolve(
+					JSON.stringify({
+						type: 'https://tools.ietf.org/html/rfc9110#section-15.6.4',
+						title: 'Service Unavailable',
+						status: 503,
+						detail: 'No puzzle available today.',
+						code: 'puzzle_unavailable'
+					})
+				)
+		} as Response;
+
+		vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		const err = await fetchGameState().catch((e) => e);
+		expect(err).toBeInstanceOf(ApiResponseError);
+		expect((err as ApiResponseError).status).toBe(503);
+		expect((err as ApiResponseError).code).toBe('puzzle_unavailable');
+		expect((err as ApiResponseError).message).toBe('No puzzle available today.');
+	});
+
 	it('throws error detail from ProblemDetails payload when request fails', async () => {
 		const mockResponse = {
 			ok: false,

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
@@ -33,7 +33,7 @@ async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 		if (bodyText) {
 			try {
 				const payload = JSON.parse(bodyText);
-				message = payload?.message ?? message;
+				message = payload?.detail ?? payload?.message ?? message;
 				code = payload?.code;
 			} catch {
 				message = bodyText;


### PR DESCRIPTION
## Summary

- All controller error responses now return RFC 9457 `ProblemDetails` JSON with a `detail` field instead of ad-hoc `{ message }` objects
- `GameController`: BadRequest/Conflict/403 use `ProblemDetails`; 503 retains the `code` extension for `puzzle_unavailable` which the frontend already reads via `payload.code`
- `AuthController`: Conflict (display name / email taken) and Unauthorized (bad credentials) use `ProblemDetails`
- `AdminController`: BadRequest and Conflict use `ProblemDetails`
- Frontend `api.ts`: reads `payload.detail` first, falls back to `payload.message` for any remaining legacy callers
- Added a Vitest test that verifies ProblemDetails `detail` field is used as the error message
- Updated `GameControllerTests` to assert on `ProblemDetails.Detail` instead of `{ message }`

## Test plan

- [x] 69 backend xUnit tests pass
- [x] 38 frontend Vitest unit tests pass (including new ProblemDetails test)
- [x] 23 Playwright UI tests pass
- [x] CI runs full E2E suite on push

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)