### PR TITLE
Add guess count distribution chart to stats page

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
@@ -171,6 +171,7 @@ public class StatsController(
             stats.PracticeAttempts,
             stats.CurrentStreak,
             stats.LongestStreak,
-            stats.AverageGuessCount);
+            stats.AverageGuessCount,
+            stats.GuessDistribution);
     }
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/PlayerStatsResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/PlayerStatsResponse.cs
@@ -7,4 +7,5 @@ public record PlayerStatsResponse(
     int PracticeAttempts,
     int CurrentStreak,
     int LongestStreak,
-    double? AverageGuessCount);
+    double? AverageGuessCount,
+    IReadOnlyDictionary<int, int> GuessDistribution);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/PlayerStatisticsService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/PlayerStatisticsService.cs
@@ -39,6 +39,11 @@ public class PlayerStatisticsService : IPlayerStatisticsService
 
         var (currentStreak, longestStreak) = CalculateStreaks(countedAttempts);
 
+        var guessDistribution = countedAttempts
+            .Where(a => a.Status == AttemptStatus.Solved && a.GuessCount.HasValue)
+            .GroupBy(a => a.GuessCount!.Value)
+            .ToDictionary(g => g.Key, g => g.Count());
+
         return new PlayerStatistics
         {
             TotalAttempts = totalAttempts,
@@ -47,7 +52,8 @@ public class PlayerStatisticsService : IPlayerStatisticsService
             CurrentStreak = currentStreak,
             LongestStreak = longestStreak,
             AverageGuessCount = averageGuesses,
-            PracticeAttempts = practiceAttempts.Count
+            PracticeAttempts = practiceAttempts.Count,
+            GuessDistribution = guessDistribution
         };
     }
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/PlayerStatistics.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/PlayerStatistics.cs
@@ -9,4 +9,5 @@ public class PlayerStatistics
     public int CurrentStreak { get; set; }
     public int LongestStreak { get; set; }
     public double? AverageGuessCount { get; set; }
+    public IReadOnlyDictionary<int, int> GuessDistribution { get; set; } = new Dictionary<int, int>();
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerStatisticsServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/PlayerStatisticsServiceTests.cs
@@ -176,6 +176,43 @@ public class PlayerStatisticsServiceTests
         stats.PracticeAttempts.Should().Be(1);
     }
 
+    [Fact]
+    public void Calculate_returns_guess_distribution_for_solved_attempts()
+    {
+        var player = CreatePlayer();
+        player.Attempts =
+        [
+            CreateAttempt(player, new DateOnly(2025, 3, 1), AttemptStatus.Solved, true, 2),
+            CreateAttempt(player, new DateOnly(2025, 3, 2), AttemptStatus.Solved, true, 3),
+            CreateAttempt(player, new DateOnly(2025, 3, 3), AttemptStatus.Solved, true, 3),
+            CreateAttempt(player, new DateOnly(2025, 3, 4), AttemptStatus.Failed, true, 6),
+        ];
+
+        var service = new PlayerStatisticsService();
+        var stats = service.Calculate(player, null, _ => false);
+
+        stats.GuessDistribution.Should().BeEquivalentTo(new Dictionary<int, int>
+        {
+            [2] = 1,
+            [3] = 2
+        });
+    }
+
+    [Fact]
+    public void Calculate_returns_empty_distribution_when_no_solved_attempts()
+    {
+        var player = CreatePlayer();
+        player.Attempts =
+        [
+            CreateAttempt(player, new DateOnly(2025, 3, 5), AttemptStatus.Failed, true, 6),
+        ];
+
+        var service = new PlayerStatisticsService();
+        var stats = service.Calculate(player, null, _ => false);
+
+        stats.GuessDistribution.Should().BeEmpty();
+    }
+
     private static PlayerPuzzleAttempt CreateAttempt(
         Player player,
         DateOnly puzzleDate,

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -1139,6 +1139,14 @@
 						"type": "number",
 						"format": "double",
 						"nullable": true
+					},
+					"guessDistribution": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "integer",
+							"format": "int32"
+						},
+						"nullable": true
 					}
 				},
 				"additionalProperties": false

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/PlayerStatsResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/PlayerStatsResponse.ts
@@ -10,4 +10,5 @@ export type PlayerStatsResponse = {
 	currentStreak?: number;
 	longestStreak?: number;
 	averageGuessCount?: number | null;
+	guessDistribution?: Record<string, number>;
 };

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/types.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/types.ts
@@ -60,4 +60,5 @@ export type PlayerStatsResponse = {
 	currentStreak: number;
 	longestStreak: number;
 	averageGuessCount?: number | null;
+	guessDistribution?: Record<string, number>;
 };

--- a/src/Wordle.TrackerSupreme.Web/src/routes/stats/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/stats/+page.svelte
@@ -321,6 +321,32 @@
 										<div class="text-lg font-semibold text-white">{entry.stats.longestStreak}</div>
 									</div>
 								</div>
+								{#if entry.stats.guessDistribution && Object.keys(entry.stats.guessDistribution).length > 0}
+									{@const dist = entry.stats.guessDistribution}
+									{@const maxCount = Math.max(...Object.values(dist))}
+									<div class="mt-4" data-testid="guess-distribution">
+										<p class="text-xs tracking-[0.2em] text-slate-200/60 uppercase">
+											Guess distribution
+										</p>
+										<div class="mt-2 space-y-1">
+											{#each [1, 2, 3, 4, 5, 6] as n (n)}
+												{@const count = dist[n] ?? 0}
+												<div class="flex items-center gap-2 text-xs">
+													<span class="w-3 shrink-0 text-right text-slate-200/70">{n}</span>
+													<div class="flex-1">
+														<div
+															class="h-5 rounded-sm bg-emerald-500/70 transition-all"
+															style="width: {maxCount > 0
+																? Math.max((count / maxCount) * 100, count > 0 ? 4 : 0)
+																: 0}%"
+														></div>
+													</div>
+													<span class="w-5 text-right text-slate-200/80">{count}</span>
+												</div>
+											{/each}
+										</div>
+									</div>
+								{/if}
 							</div>
 						{/each}
 					</div>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/stats-guess-distribution.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/stats-guess-distribution.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+test('stats page shows guess distribution bars when data is present', async ({ page }) => {
+	page.on('pageerror', (error) => {
+		console.error('pageerror', error);
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/stats/players', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify([
+				{
+					playerId: '22222222-2222-2222-2222-222222222222',
+					displayName: 'Rival',
+					stats: {
+						totalAttempts: 5,
+						wins: 4,
+						failures: 1,
+						practiceAttempts: 0,
+						currentStreak: 4,
+						longestStreak: 5,
+						averageGuessCount: 3,
+						guessDistribution: { '2': 1, '3': 2, '4': 1 }
+					}
+				}
+			])
+		});
+	});
+
+	await page.goto('/stats', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	const distribution = page.locator('[data-testid="guess-distribution"]');
+	await expect(distribution).toBeVisible();
+	await expect(distribution.getByText('Guess distribution', { exact: false })).toBeVisible();
+
+	// Rows 1–6 are always rendered; the counts for guesses 2,3,4 should be > 0
+	const rows = distribution.locator('.flex.items-center');
+	await expect(rows).toHaveCount(6);
+});
+
+test('stats page hides guess distribution when no wins', async ({ page }) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/stats/players', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify([
+				{
+					playerId: '22222222-2222-2222-2222-222222222222',
+					displayName: 'Rival',
+					stats: {
+						totalAttempts: 2,
+						wins: 0,
+						failures: 2,
+						practiceAttempts: 0,
+						currentStreak: 0,
+						longestStreak: 0,
+						averageGuessCount: null,
+						guessDistribution: {}
+					}
+				}
+			])
+		});
+	});
+
+	await page.goto('/stats', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.locator('[data-testid="guess-distribution"]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- Adds `guessDistribution: Record<int, int>` (guess number → win count) to the `PlayerStatistics` domain model and computes it in `PlayerStatisticsService` from solved attempts
- Exposes the field in `PlayerStatsResponse` DTO and maps it in `StatsController`
- Updates the TypeScript API client type (`PlayerStatsResponse`) and local `game/types.ts`
- Renders horizontal proportion bars (rows 1–6, classic Wordle style) beneath each player card on the `/stats` page; hidden when the player has no solved attempts

## Test plan

- [x] 2 new xUnit tests in `PlayerStatisticsServiceTests`: distribution populated for solved attempts, empty when no wins
- [x] 2 new Playwright UI tests in `stats-guess-distribution.spec.ts`: distribution visible with data, hidden with empty distribution
- [x] All 71 backend tests pass
- [x] All 37 frontend unit tests pass
- [x] All 4 stats UI tests pass (including pre-existing ones)
- [x] ESLint clean on `src/`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)