### PR TITLE
Add structured logging and correlation IDs

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AuthController.cs
@@ -16,7 +16,8 @@ public class AuthController(
     IPlayerRepository playerRepository,
     JwtTokenService tokenService,
     PasswordHasher<Player> passwordHasher,
-    IWebHostEnvironment environment)
+    IWebHostEnvironment environment,
+    ILogger<AuthController> logger)
     : ControllerBase
 {
     [EnableRateLimiting(AuthRateLimiting.PolicyName)]
@@ -49,6 +50,7 @@ public class AuthController(
 
         await playerRepository.AddPlayer(player, cancellationToken);
 
+        logger.LogInformation("Player registered. PlayerId={PlayerId} DisplayName={DisplayName}", player.Id, player.DisplayName);
         SignInPlayer(player);
         return Ok(new AuthResponse(MapPlayer(player), null));
     }
@@ -63,15 +65,18 @@ public class AuthController(
 
         if (player is null)
         {
+            logger.LogWarning("Sign-in failed: email not found. Email={Email}", email);
             return Unauthorized(new { message = "Invalid credentials." });
         }
 
         var verification = passwordHasher.VerifyHashedPassword(player, player.PasswordHash, request.Password);
         if (verification == PasswordVerificationResult.Failed)
         {
+            logger.LogWarning("Sign-in failed: wrong password. PlayerId={PlayerId}", player.Id);
             return Unauthorized(new { message = "Invalid credentials." });
         }
 
+        logger.LogInformation("Player signed in. PlayerId={PlayerId}", player.Id);
         SignInPlayer(player);
         return Ok(new AuthResponse(MapPlayer(player), null));
     }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
@@ -14,7 +14,8 @@ namespace Wordle.TrackerSupreme.Api.Controllers;
 [Authorize]
 public class GameController(
     IGameplayService gameplayService,
-    IGameClock gameClock) : ControllerBase
+    IGameClock gameClock,
+    ILogger<GameController> logger) : ControllerBase
 {
     [HttpGet("state")]
     public async Task<ActionResult<GameStateResponse>> GetState(CancellationToken cancellationToken)
@@ -48,6 +49,7 @@ public class GameController(
         try
         {
             var state = await gameplayService.SubmitGuess(playerId.Value, request.Guess, cancellationToken);
+            logger.LogInformation("Guess submitted. PlayerId={PlayerId} PuzzleDate={PuzzleDate}", playerId, state.Puzzle.PuzzleDate);
             return Ok(MapState(state));
         }
         catch (DailyPuzzleUnavailableException ex)
@@ -80,6 +82,7 @@ public class GameController(
         try
         {
             var state = await gameplayService.EnableEasyMode(playerId.Value, cancellationToken);
+            logger.LogInformation("Easy mode enabled. PlayerId={PlayerId}", playerId);
             return Ok(MapState(state));
         }
         catch (DailyPuzzleUnavailableException ex)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,19 @@
+namespace Wordle.TrackerSupreme.Api.Middleware;
+
+public class CorrelationIdMiddleware(RequestDelegate next)
+{
+    private const string HeaderName = "X-Correlation-ID";
+
+    public async Task InvokeAsync(HttpContext context, ILogger<CorrelationIdMiddleware> logger)
+    {
+        var correlationId = context.Request.Headers[HeaderName].FirstOrDefault()
+            ?? Guid.NewGuid().ToString();
+
+        context.Response.Headers[HeaderName] = correlationId;
+
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
+        {
+            await next(context);
+        }
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using System.Threading.RateLimiting;
 using Wordle.TrackerSupreme.Api.Auth;
+using Wordle.TrackerSupreme.Api.Middleware;
 using Wordle.TrackerSupreme.Application.Services.Admin;
 using Wordle.TrackerSupreme.Application.Services.Game;
 using Wordle.TrackerSupreme.Application.Services;
@@ -19,6 +20,20 @@ using Wordle.TrackerSupreme.Infrastructure.Database;
 using Wordle.TrackerSupreme.Migrations;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+if (builder.Environment.IsDevelopment())
+{
+    builder.Logging.AddConsole();
+}
+else
+{
+    builder.Logging.AddJsonConsole(options =>
+    {
+        options.IncludeScopes = true;
+        options.TimestampFormat = "o";
+    });
+}
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -202,6 +217,7 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseForwardedHeaders();
+app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseCors();
 app.UseRateLimiter();
 app.UseAuthentication();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Wordle.TrackerSupreme.Api.Auth;
 using Wordle.TrackerSupreme.Api.Controllers;
@@ -41,7 +42,8 @@ public class AuthControllerTests
             repository,
             new JwtTokenService(jwtSettings),
             new PasswordHasher<Player>(),
-            env)
+            env,
+            NullLogger<AuthController>.Instance)
         {
             ControllerContext = new ControllerContext
             {

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/CorrelationIdMiddlewareTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/CorrelationIdMiddlewareTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wordle.TrackerSupreme.Api.Middleware;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class CorrelationIdMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_sets_correlation_id_response_header_when_absent_from_request()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        var middleware = new CorrelationIdMiddleware(_ => Task.CompletedTask);
+        var logger = NullLogger<CorrelationIdMiddleware>.Instance;
+
+        await middleware.InvokeAsync(context, logger);
+
+        context.Response.Headers.ContainsKey("X-Correlation-ID").Should().BeTrue();
+        var header = context.Response.Headers["X-Correlation-ID"].ToString();
+        Guid.TryParse(header, out _).Should().BeTrue("header value should be a valid GUID");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_echoes_correlation_id_from_request_header()
+    {
+        var correlationId = "my-fixed-correlation-id";
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Correlation-ID"] = correlationId;
+        context.Response.Body = new MemoryStream();
+
+        var middleware = new CorrelationIdMiddleware(_ => Task.CompletedTask);
+        var logger = NullLogger<CorrelationIdMiddleware>.Instance;
+
+        await middleware.InvokeAsync(context, logger);
+
+        context.Response.Headers["X-Correlation-ID"].ToString().Should().Be(correlationId);
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
@@ -35,7 +35,7 @@ public class GameControllerTests
             clock,
             new GuessEvaluationService(options, validator),
             options);
-        var controller = new GameController(gameplay, clock)
+        var controller = new GameController(gameplay, clock, NullLogger<GameController>.Instance)
         {
             ControllerContext = new ControllerContext
             {


### PR DESCRIPTION
## Summary

- Switches to **JSON console logging** in non-development environments using the built-in `Microsoft.Extensions.Logging.Console` JSON formatter (no new NuGet packages)
- Adds **`CorrelationIdMiddleware`**: reads `X-Correlation-ID` from the incoming request or generates a new GUID, echoes it in the response header, and wraps the handler in a structured log scope so every log entry emitted during the request automatically carries `"CorrelationId"` as a top-level JSON field
- Adds **structured log events** to key controllers:
  - `GameController`: `Guess submitted` (PlayerId, PuzzleDate), `Easy mode enabled` (PlayerId)
  - `AuthController`: `Player registered`, `Player signed in`, `Sign-in failed` (with reason)

## Test plan

- [x] 2 new xUnit tests in `CorrelationIdMiddlewareTests`: generates a GUID header when absent, echoes caller's ID when present
- [x] Existing `GameControllerTests` (8 tests) and `AuthControllerTests` (7 tests) updated for new logger constructor parameters — all still pass
- [x] 71 / 71 backend tests pass

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)