### PR TITLE
Add leaderboard pagination (#34)

### DIFF
--- a/.codex/agent-loop.md
+++ b/.codex/agent-loop.md
@@ -45,3 +45,11 @@
 - what action you took: committed the change as `a222a70` (`Increase win confetti burst`), pushed branch `codex/issue-57-more-confetti`, and opened draft PR `#72` (`[codex] Increase win confetti burst`) targeting `main`.
 - what is blocked: nothing immediate on the published work; PR `#72` is open and waiting for review/comments.
 - what should be done next: re-query GitHub state, prioritize any comments or CI changes on `#72`, and if none appear take the next uncovered open issue, with `#45` as the best remaining product-facing candidate.
+
+## 2026-04-18T00:00:00+02:00
+- what you inspected: open PRs (#79 REVIEW_REQUIRED), open issues, game/types.ts, PlayerStatisticsService, PlayerStatsResponse DTO, StatsController, stats page, openapi.json, api-client models.
+- what action you took:
+  1. Implemented issue #24 (Guess count distribution chart): added `GuessDistribution` to domain model + service, DTO, controller MapStats; updated TypeScript client + local types; added horizontal bar chart (rows 1-6) to stats page; 2 new xUnit tests + 2 new Playwright UI tests. All 71 backend + 37 frontend unit + 4 UI tests pass. Opened PR #80.
+  2. Implemented issue #41 (Structured logging): added CorrelationIdMiddleware (reads/generates X-Correlation-ID, adds to log scope + response header), JSON console logging for non-dev, structured log events in GameController and AuthController. 2 new middleware unit tests. All 71 backend tests pass. Opened PR #81.
+- what is blocked: PR #79 (#35 ProblemDetails), PR #80 (#24 distribution), PR #81 (#41 logging) all awaiting review — cannot self-merge.
+- what should be done next: continue with unassigned issues. Issue #34 (leaderboard pagination) or #38 (mobile UX) are next candidates.

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
@@ -59,8 +59,14 @@ public class StatsController(
     }
 
     [HttpGet("leaderboard")]
-    public async Task<ActionResult<IReadOnlyList<LeaderboardEntryResponse>>> GetLeaderboard(CancellationToken cancellationToken)
+    public async Task<ActionResult<LeaderboardPageResponse>> GetLeaderboard(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        CancellationToken cancellationToken = default)
     {
+        page = Math.Max(1, page);
+        pageSize = Math.Clamp(pageSize, 1, 100);
+
         var filter = new PlayerStatsFilterRequest(
             IncludeHardMode: true,
             IncludeEasyMode: false,
@@ -92,10 +98,15 @@ public class StatsController(
             .ThenBy(entry => entry.Player.DisplayName)
             .ToList();
 
-        var leaderboard = new List<LeaderboardEntryResponse>();
-        var rank = 1;
+        var total = ranked.Count;
+        var totalPages = total == 0 ? 1 : (int)Math.Ceiling((double)total / pageSize);
+        page = Math.Min(page, totalPages);
 
-        foreach (var entry in ranked)
+        var leaderboard = new List<LeaderboardEntryResponse>();
+        var globalRankStart = (page - 1) * pageSize + 1;
+        var rank = globalRankStart;
+
+        foreach (var entry in ranked.Skip((page - 1) * pageSize).Take(pageSize))
         {
             leaderboard.Add(new LeaderboardEntryResponse(
                 rank,
@@ -112,7 +123,7 @@ public class StatsController(
             rank += 1;
         }
 
-        return Ok(leaderboard);
+        return Ok(new LeaderboardPageResponse(leaderboard, total, page, pageSize, totalPages));
     }
 
     [HttpGet("leaderboard/today")]

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/LeaderboardPageResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/LeaderboardPageResponse.cs
@@ -1,0 +1,8 @@
+namespace Wordle.TrackerSupreme.Api.Models.Game;
+
+public record LeaderboardPageResponse(
+    IReadOnlyList<LeaderboardEntryResponse> Items,
+    int Total,
+    int Page,
+    int PageSize,
+    int TotalPages);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
@@ -48,17 +48,18 @@ public class StatsControllerTests
         var repo = new FakePlayerRepository([consistent, sharp]);
         var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 2)));
 
-        var result = await controller.GetLeaderboard(CancellationToken.None);
+        var result = await controller.GetLeaderboard(cancellationToken: CancellationToken.None);
         var okResult = result.Result as OkObjectResult;
 
         okResult.Should().NotBeNull();
-        var payload = okResult!.Value.Should().BeAssignableTo<IReadOnlyList<LeaderboardEntryResponse>>().Subject;
+        var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;
 
-        payload.Should().HaveCount(2);
-        payload.First().DisplayName.Should().Be("Sharp");
-        payload.First().Rank.Should().Be(1);
-        payload.Last().DisplayName.Should().Be("Consistent");
-        payload.Last().Rank.Should().Be(2);
+        payload.Items.Should().HaveCount(2);
+        payload.Total.Should().Be(2);
+        payload.Items.First().DisplayName.Should().Be("Sharp");
+        payload.Items.First().Rank.Should().Be(1);
+        payload.Items.Last().DisplayName.Should().Be("Consistent");
+        payload.Items.Last().Rank.Should().Be(2);
     }
 
     [Fact]
@@ -103,14 +104,63 @@ public class StatsControllerTests
         var repo = new FakePlayerRepository([emptyPlayer, activePlayer]);
         var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 2)));
 
-        var result = await controller.GetLeaderboard(CancellationToken.None);
+        var result = await controller.GetLeaderboard(cancellationToken: CancellationToken.None);
         var okResult = result.Result as OkObjectResult;
 
         okResult.Should().NotBeNull();
-        var payload = okResult!.Value.Should().BeAssignableTo<IReadOnlyList<LeaderboardEntryResponse>>().Subject;
+        var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;
 
-        payload.Should().HaveCount(1);
-        payload.Single().DisplayName.Should().Be("Active");
+        payload.Items.Should().HaveCount(1);
+        payload.Items.Single().DisplayName.Should().Be("Active");
+        payload.Total.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetLeaderboard_returns_correct_page_slice_and_metadata()
+    {
+        var players = Enumerable.Range(1, 5)
+            .Select(i =>
+            {
+                var p = CreatePlayer($"Player{i}");
+                p.Attempts.Add(CreateAttempt(p, new DateOnly(2025, 1, i), AttemptStatus.Solved, true, i));
+                return p;
+            })
+            .ToList();
+
+        var repo = new FakePlayerRepository(players);
+        var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 6)));
+
+        var result = await controller.GetLeaderboard(page: 2, pageSize: 2, CancellationToken.None);
+        var okResult = result.Result as OkObjectResult;
+
+        okResult.Should().NotBeNull();
+        var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;
+
+        payload.Total.Should().Be(5);
+        payload.Page.Should().Be(2);
+        payload.PageSize.Should().Be(2);
+        payload.TotalPages.Should().Be(3);
+        payload.Items.Should().HaveCount(2);
+        // Page 2 has global ranks 3 and 4
+        payload.Items.First().Rank.Should().Be(3);
+        payload.Items.Last().Rank.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetLeaderboard_clamps_page_to_last_page_when_out_of_range()
+    {
+        var player = CreatePlayer("Solo");
+        player.Attempts.Add(CreateAttempt(player, new DateOnly(2025, 1, 1), AttemptStatus.Solved, true, 2));
+
+        var repo = new FakePlayerRepository([player]);
+        var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 2)));
+
+        var result = await controller.GetLeaderboard(page: 99, pageSize: 10, CancellationToken.None);
+        var okResult = result.Result as OkObjectResult;
+
+        var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;
+        payload.Page.Should().Be(1);
+        payload.Items.Should().HaveCount(1);
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -641,32 +641,43 @@
 		"/api/stats/leaderboard": {
 			"get": {
 				"tags": ["Stats"],
+				"parameters": [
+					{
+						"name": "page",
+						"in": "query",
+						"schema": {
+							"type": "integer",
+							"format": "int32",
+							"default": 1
+						}
+					},
+					{
+						"name": "pageSize",
+						"in": "query",
+						"schema": {
+							"type": "integer",
+							"format": "int32",
+							"default": 10
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
 						"content": {
 							"text/plain": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/LeaderboardEntryResponse"
-									}
+									"$ref": "#/components/schemas/LeaderboardPageResponse"
 								}
 							},
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/LeaderboardEntryResponse"
-									}
+									"$ref": "#/components/schemas/LeaderboardPageResponse"
 								}
 							},
 							"text/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/LeaderboardEntryResponse"
-									}
+									"$ref": "#/components/schemas/LeaderboardPageResponse"
 								}
 							}
 						}
@@ -987,6 +998,35 @@
 					},
 					"result": {
 						"type": "string"
+					}
+				},
+				"additionalProperties": false
+			},
+			"LeaderboardPageResponse": {
+				"type": "object",
+				"properties": {
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/LeaderboardEntryResponse"
+						},
+						"nullable": true
+					},
+					"total": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"page": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"pageSize": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"totalPages": {
+						"type": "integer",
+						"format": "int32"
 					}
 				},
 				"additionalProperties": false

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
@@ -19,6 +19,7 @@ export type { AuthResponse } from './models/AuthResponse';
 export type { GameStateResponse } from './models/GameStateResponse';
 export type { GuessResponse } from './models/GuessResponse';
 export type { LeaderboardEntryResponse } from './models/LeaderboardEntryResponse';
+export type { LeaderboardPageResponse } from './models/LeaderboardPageResponse';
 export type { LetterFeedbackResponse } from './models/LetterFeedbackResponse';
 export type { PlayerResponse } from './models/PlayerResponse';
 export type { PlayerStatsEntryResponse } from './models/PlayerStatsEntryResponse';

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/LeaderboardPageResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/LeaderboardPageResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { LeaderboardEntryResponse } from './LeaderboardEntryResponse';
+export type LeaderboardPageResponse = {
+	items?: Array<LeaderboardEntryResponse> | null;
+	total?: number;
+	page?: number;
+	pageSize?: number;
+	totalPages?: number;
+};

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { LeaderboardEntryResponse } from '../models/LeaderboardEntryResponse';
+import type { LeaderboardPageResponse } from '../models/LeaderboardPageResponse';
 import type { PlayerStatsEntryResponse } from '../models/PlayerStatsEntryResponse';
 import type { PlayerStatsFilterRequest } from '../models/PlayerStatsFilterRequest';
 import type { PlayerStatsResponse } from '../models/PlayerStatsResponse';
@@ -38,13 +39,23 @@ export class StatsService {
 		});
 	}
 	/**
-	 * @returns LeaderboardEntryResponse OK
+	 * @returns LeaderboardPageResponse OK
 	 * @throws ApiError
 	 */
-	public static getApiStatsLeaderboard(): CancelablePromise<Array<LeaderboardEntryResponse>> {
+	public static getApiStatsLeaderboard({
+		page,
+		pageSize
+	}: {
+		page?: number;
+		pageSize?: number;
+	} = {}): CancelablePromise<LeaderboardPageResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
-			url: '/api/stats/leaderboard'
+			url: '/api/stats/leaderboard',
+			query: {
+				page,
+				pageSize
+			}
 		});
 	}
 	/**

--- a/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
@@ -7,6 +7,8 @@
 	import type { TodayLeaderboardEntryResponse } from '$lib/api-client/models/TodayLeaderboardEntryResponse';
 	import { formatTodayLeaderboardMeta } from '$lib/stats/leaderboard';
 
+	const PAGE_SIZE = 10;
+
 	type LeaderboardTab = 'all-time' | 'today';
 
 	type LeaderboardTabContent = {
@@ -20,19 +22,22 @@
 			title: 'Hard mode before noon',
 			description:
 				'Ranked by win rate, then average guesses, across hard-mode attempts submitted before the daily reveal.',
-			emptyState: 'No leaderboard entries yet. Solve today’s puzzle to claim the top spot.'
+			emptyState: "No leaderboard entries yet. Solve today's puzzle to claim the top spot."
 		},
 		today: {
 			title: "Today's puzzle",
 			description:
-				'See who has finished today’s puzzle, how many guesses it took, and who is still playing right now.',
-			emptyState: 'No one has submitted an attempt for today’s puzzle yet.'
+				"See who has finished today's puzzle, how many guesses it took, and who is still playing right now.",
+			emptyState: "No one has submitted an attempt for today's puzzle yet."
 		}
 	};
 
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 	let allTimeEntries = $state<LeaderboardEntryResponse[]>([]);
+	let allTimePage = $state(1);
+	let allTimeTotalPages = $state(1);
+	let allTimeTotal = $state(0);
 	let todayEntries = $state<TodayLeaderboardEntryResponse[]>([]);
 	let hasLoaded = $state(false);
 	let activeTab = $state<LeaderboardTab>('all-time');
@@ -69,6 +74,24 @@
 		return 'bg-amber-400/15 text-amber-100 ring-1 ring-amber-300/20';
 	}
 
+	async function loadAllTime(page: number) {
+		if (!$auth.user) return;
+		loading = true;
+		error = null;
+		try {
+			const data = await StatsService.getApiStatsLeaderboard({ page, pageSize: PAGE_SIZE });
+			allTimeEntries = data.items ?? [];
+			allTimePage = data.page ?? 1;
+			allTimeTotalPages = data.totalPages ?? 1;
+			allTimeTotal = data.total ?? 0;
+			loadedTabs['all-time'] = true;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Unable to load leaderboard.';
+		} finally {
+			loading = false;
+		}
+	}
+
 	async function loadLeaderboard(tab: LeaderboardTab) {
 		if (!$auth.user) {
 			return;
@@ -77,7 +100,8 @@
 		error = null;
 		try {
 			if (tab === 'all-time') {
-				allTimeEntries = await StatsService.getApiStatsLeaderboard();
+				await loadAllTime(1);
+				return;
 			} else {
 				todayEntries = await StatsService.getApiStatsLeaderboardToday();
 			}
@@ -87,6 +111,10 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	async function goToPage(page: number) {
+		await loadAllTime(page);
 	}
 
 	async function selectTab(tab: LeaderboardTab) {
@@ -233,6 +261,32 @@
 					</tbody>
 				</table>
 			</div>
+			{#if allTimeTotalPages > 1}
+				<div
+					class="mt-4 flex items-center justify-between text-sm text-slate-200/70"
+					data-testid="leaderboard-pagination"
+				>
+					<span>{allTimeTotal} players · page {allTimePage} of {allTimeTotalPages}</span>
+					<div class="flex gap-2">
+						<button
+							class="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+							disabled={allTimePage <= 1 || loading}
+							data-testid="leaderboard-prev"
+							on:click={() => void goToPage(allTimePage - 1)}
+						>
+							← Previous
+						</button>
+						<button
+							class="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+							disabled={allTimePage >= allTimeTotalPages || loading}
+							data-testid="leaderboard-next"
+							on:click={() => void goToPage(allTimePage + 1)}
+						>
+							Next →
+						</button>
+					</div>
+				</div>
+			{/if}
 		{:else}
 			<div class="overflow-hidden rounded-3xl border border-white/10 bg-black/30 shadow-xl">
 				<table class="w-full text-left text-sm text-slate-200/80" data-testid="leaderboard-table">

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-empty.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-empty.spec.ts
@@ -18,11 +18,11 @@ test('leaderboard shows empty state when no entries', async ({ page }) => {
 		});
 	});
 
-	await page.route('**/api/stats/leaderboard', async (route) => {
+	await page.route('**/api/stats/leaderboard**', async (route) => {
 		await route.fulfill({
 			status: 200,
 			contentType: 'application/json',
-			body: JSON.stringify([])
+			body: JSON.stringify({ items: [], total: 0, page: 1, pageSize: 10, totalPages: 1 })
 		});
 	});
 

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-pagination.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-pagination.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+
+test('leaderboard shows pagination controls when more than one page', async ({ page }) => {
+	const requestedPages: number[] = [];
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route(
+		(url) => url.href.includes('/api/stats/leaderboard') && !url.href.includes('/today'),
+		async (route) => {
+			const url = new URL(route.request().url());
+			const requestedPage = parseInt(url.searchParams.get('page') ?? '1', 10);
+			requestedPages.push(requestedPage);
+
+			const entry = (rank: number, name: string, id: string) => ({
+				rank,
+				playerId: id,
+				displayName: name,
+				totalAttempts: 5,
+				wins: 4,
+				failures: 1,
+				currentStreak: 4,
+				longestStreak: 5,
+				practiceAttempts: 0,
+				averageGuessCount: 3,
+				winRate: 0.8
+			});
+
+			if (requestedPage === 1) {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						items: [entry(1, 'Alice', '11111111-0000-0000-0000-000000000001')],
+						total: 15,
+						page: 1,
+						pageSize: 10,
+						totalPages: 2
+					})
+				});
+			} else {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						items: [entry(11, 'Zack', '11111111-0000-0000-0000-000000000002')],
+						total: 15,
+						page: 2,
+						pageSize: 10,
+						totalPages: 2
+					})
+				});
+			}
+		}
+	);
+
+	await page.goto('/leaderboard', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	// Pagination controls should be visible
+	const pagination = page.locator('[data-testid="leaderboard-pagination"]');
+	await expect(pagination).toBeVisible();
+	await expect(page.locator('[data-testid="leaderboard-prev"]')).toBeDisabled();
+	await expect(page.locator('[data-testid="leaderboard-next"]')).toBeEnabled();
+
+	// Navigate to page 2
+	await page.locator('[data-testid="leaderboard-next"]').click();
+
+	await expect(page.getByRole('cell', { name: 'Zack' })).toBeVisible();
+	await expect(page.locator('[data-testid="leaderboard-prev"]')).toBeEnabled();
+	await expect(page.locator('[data-testid="leaderboard-next"]')).toBeDisabled();
+
+	expect(requestedPages).toContain(2);
+});
+
+test('leaderboard hides pagination when only one page', async ({ page }) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/stats/leaderboard**', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				items: [
+					{
+						rank: 1,
+						playerId: '22222222-2222-2222-2222-222222222222',
+						displayName: 'Solo',
+						totalAttempts: 1,
+						wins: 1,
+						failures: 0,
+						currentStreak: 1,
+						longestStreak: 1,
+						practiceAttempts: 0,
+						averageGuessCount: 2,
+						winRate: 1
+					}
+				],
+				total: 1,
+				page: 1,
+				pageSize: 10,
+				totalPages: 1
+			})
+		});
+	});
+
+	await page.goto('/leaderboard', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByRole('cell', { name: 'Solo' })).toBeVisible();
+	await expect(page.locator('[data-testid="leaderboard-pagination"]')).toHaveCount(0);
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-today.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard-today.spec.ts
@@ -17,28 +17,37 @@ test('leaderboard can switch from all-time rankings to today standings', async (
 		});
 	});
 
-	await page.route('**/api/stats/leaderboard', async (route) => {
-		allTimeRequests += 1;
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			body: JSON.stringify([
-				{
-					rank: 1,
-					playerId: '22222222-2222-2222-2222-222222222222',
-					displayName: 'Rival',
-					totalAttempts: 5,
-					wins: 4,
-					failures: 1,
-					currentStreak: 4,
-					longestStreak: 5,
-					practiceAttempts: 0,
-					averageGuessCount: 3,
-					winRate: 0.8
-				}
-			])
-		});
-	});
+	await page.route(
+		(url) => url.href.includes('/api/stats/leaderboard') && !url.href.includes('/today'),
+		async (route) => {
+			allTimeRequests += 1;
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					items: [
+						{
+							rank: 1,
+							playerId: '22222222-2222-2222-2222-222222222222',
+							displayName: 'Rival',
+							totalAttempts: 5,
+							wins: 4,
+							failures: 1,
+							currentStreak: 4,
+							longestStreak: 5,
+							practiceAttempts: 0,
+							averageGuessCount: 3,
+							winRate: 0.8
+						}
+					],
+					total: 1,
+					page: 1,
+					pageSize: 10,
+					totalPages: 1
+				})
+			});
+		}
+	);
 
 	await page.route('**/api/stats/leaderboard/today', async (route) => {
 		todayRequests += 1;

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
@@ -23,38 +23,44 @@ test('leaderboard shows ranked hard mode entries', async ({ page }) => {
 		});
 	});
 
-	await page.route('**/api/stats/leaderboard', async (route) => {
+	await page.route('**/api/stats/leaderboard**', async (route) => {
 		await route.fulfill({
 			status: 200,
 			contentType: 'application/json',
-			body: JSON.stringify([
-				{
-					rank: 1,
-					playerId: '22222222-2222-2222-2222-222222222222',
-					displayName: 'Rival',
-					totalAttempts: 5,
-					wins: 4,
-					failures: 1,
-					currentStreak: 4,
-					longestStreak: 5,
-					practiceAttempts: 0,
-					averageGuessCount: 3,
-					winRate: 0.8
-				},
-				{
-					rank: 2,
-					playerId: '33333333-3333-3333-3333-333333333333',
-					displayName: 'Challenger',
-					totalAttempts: 3,
-					wins: 2,
-					failures: 1,
-					currentStreak: 2,
-					longestStreak: 3,
-					practiceAttempts: 0,
-					averageGuessCount: 4,
-					winRate: 0.66
-				}
-			])
+			body: JSON.stringify({
+				items: [
+					{
+						rank: 1,
+						playerId: '22222222-2222-2222-2222-222222222222',
+						displayName: 'Rival',
+						totalAttempts: 5,
+						wins: 4,
+						failures: 1,
+						currentStreak: 4,
+						longestStreak: 5,
+						practiceAttempts: 0,
+						averageGuessCount: 3,
+						winRate: 0.8
+					},
+					{
+						rank: 2,
+						playerId: '33333333-3333-3333-3333-333333333333',
+						displayName: 'Challenger',
+						totalAttempts: 3,
+						wins: 2,
+						failures: 1,
+						currentStreak: 2,
+						longestStreak: 3,
+						practiceAttempts: 0,
+						averageGuessCount: 4,
+						winRate: 0.66
+					}
+				],
+				total: 2,
+				page: 1,
+				pageSize: 10,
+				totalPages: 1
+			})
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Added `LeaderboardPageResponse` DTO wrapping items with `total`, `page`, `pageSize`, and `totalPages`
- `GET /api/stats/leaderboard` now accepts `page` and `pageSize` query parameters (defaults: 1, 10; pageSize clamped to 1–100)
- Global ranks are preserved correctly across pages using `(page-1)*pageSize` offset
- Leaderboard UI shows prev/next pagination controls when `totalPages > 1`, hidden otherwise
- All existing leaderboard UI tests updated to use the new paginated response shape
- New `leaderboard-pagination.spec.ts` with two Playwright tests covering multi-page and single-page cases
- Fixed curly/smart apostrophe in `tabContent.today.title` that caused `leaderboard-today.spec.ts` to fail

Closes #34

## Test plan

- [ ] `docker compose --profile tests run --rm tests-backend` — StatsController pagination tests pass
- [ ] `npx playwright test tests/ui/leaderboard*.spec.ts` — all 6 leaderboard UI tests pass
- [ ] Navigate to `/leaderboard` with >10 entries — prev/next controls appear and work
- [ ] Navigate to `/leaderboard` with ≤10 entries — no pagination controls shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)