### PR TITLE
Fix keyboard highlights not updating after guesses (#83)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 		type ConfettiPiece
 	} from '$lib/game/confetti';
 	import { getKeyboardLetterState } from '$lib/game/keyboard';
-	import type { GameStateResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
+	import type { GameStateResponse, GuessResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
 	import { onMount, tick } from 'svelte';
 
 	let checking = true;
@@ -278,14 +278,14 @@
 		return `animation-delay:${position * 220}ms`;
 	}
 
-	function keyState(letter: string): LetterResult | null {
-		return getKeyboardLetterState(state?.attempt?.guesses, letter);
+	function keyState(letter: string, guesses: GuessResponse[] | null | undefined): LetterResult | null {
+		return getKeyboardLetterState(guesses, letter);
 	}
 
-	function keyClass(letter: string) {
+	function keyClass(letter: string, guesses: GuessResponse[] | null | undefined) {
 		const base =
 			'flex h-11 items-center justify-center rounded-xl border px-3 text-sm font-semibold uppercase transition';
-		const stateKey = keyState(letter);
+		const stateKey = keyState(letter, guesses);
 		if (stateKey === 'Correct') {
 			return `${base} border-emerald-400 bg-emerald-400 text-slate-900`;
 		}
@@ -506,11 +506,11 @@
 									{/if}
 									{#each row.split('') as letter (letter)}
 										<button
-											class={keyClass(letter)}
+											class={keyClass(letter, state?.attempt?.guesses)}
 											onclick={() => pushLetter(letter)}
 											disabled={guessInputLocked}
 											data-testid={`keyboard-key-${letter}`}
-											data-state={(keyState(letter) ?? 'unused').toLowerCase()}
+											data-state={(keyState(letter, state?.attempt?.guesses) ?? 'unused').toLowerCase()}
 										>
 											{letter}
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/keyboard-highlights-after-guess.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/keyboard-highlights-after-guess.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+
+test('on-screen keyboard updates to reflect letter states after submitting a guess', async ({
+	page
+}) => {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: null,
+				solution: null
+			})
+		});
+	});
+
+	await page.route('**/api/game/guess', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				puzzleDate: '2025-01-01',
+				cutoffPassed: false,
+				solutionRevealed: false,
+				allowLatePlay: true,
+				wordLength: 5,
+				maxGuesses: 6,
+				isHardMode: true,
+				canGuess: true,
+				attempt: {
+					attemptId: '22222222-2222-2222-2222-222222222222',
+					status: 'InProgress',
+					isAfterReveal: false,
+					createdOn: '2025-01-01T00:00:00Z',
+					completedOn: null,
+					guesses: [
+						{
+							guessId: '33333333-3333-3333-3333-333333333333',
+							guessNumber: 1,
+							guessWord: 'CRANE',
+							feedback: [
+								{ position: 0, letter: 'C', result: 'Absent' },
+								{ position: 1, letter: 'R', result: 'Present' },
+								{ position: 2, letter: 'A', result: 'Absent' },
+								{ position: 3, letter: 'N', result: 'Correct' },
+								{ position: 4, letter: 'E', result: 'Absent' }
+							]
+						}
+					]
+				},
+				solution: null
+			})
+		});
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+
+	// All keys should be unused before any guess
+	await expect(page.getByTestId('keyboard-key-C')).toHaveAttribute('data-state', 'unused');
+	await expect(page.getByTestId('keyboard-key-Z')).toHaveAttribute('data-state', 'unused');
+
+	// Submit a guess
+	await page.click('body');
+	await page.keyboard.type('CRANE');
+	await page.keyboard.press('Enter');
+
+	// Keyboard should update to reflect the evaluated letters
+	await expect(page.getByTestId('keyboard-key-C')).toHaveAttribute('data-state', 'absent');
+	await expect(page.getByTestId('keyboard-key-R')).toHaveAttribute('data-state', 'present');
+	await expect(page.getByTestId('keyboard-key-N')).toHaveAttribute('data-state', 'correct');
+	await expect(page.getByTestId('keyboard-key-A')).toHaveAttribute('data-state', 'absent');
+	await expect(page.getByTestId('keyboard-key-E')).toHaveAttribute('data-state', 'absent');
+	// Unguessed letter stays unused
+	await expect(page.getByTestId('keyboard-key-Z')).toHaveAttribute('data-state', 'unused');
+});


### PR DESCRIPTION
## Summary

- Root cause: In Svelte 4 (legacy mode), template function calls only track their **explicit arguments** as reactive dependencies — not variables closed over inside the function body. `keyState(letter)` and `keyClass(letter)` both read `state?.attempt?.guesses` via closure, so Svelte never re-ran them when `state` changed after a guess submission.
- Fix: thread `guesses` as an explicit parameter to both functions, so `state` is directly referenced in the template expression and Svelte tracks it as a reactive dependency.
- Added a new Playwright UI test (`keyboard-highlights-after-guess.spec.ts`) that submits a guess and asserts all keyboard keys update to reflect absent/present/correct feedback.

Closes #83

## Test plan

- [x] New UI test `keyboard-highlights-after-guess.spec.ts` passes
- [x] All 28 existing UI tests continue to pass (`npx playwright test tests/ui/ --reporter=line`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)