### PR TITLE
Add how-to-play modal for first-time users (#30)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/playwright.e2e.config.ts
+++ b/src/Wordle.TrackerSupreme.Web/playwright.e2e.config.ts
@@ -6,6 +6,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const artifactRoot =
 	process.env.E2E_ARTIFACT_DIR ?? path.resolve(__dirname, '../../artifacts/e2e/playwright');
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
 
 export default defineConfig({
 	testDir: './tests/e2e',
@@ -21,11 +22,20 @@ export default defineConfig({
 		['html', { outputFolder: path.join(artifactRoot, 'report'), open: 'never' }]
 	],
 	use: {
-		baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+		baseURL,
 		headless: true,
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
-		video: 'retain-on-failure'
+		video: 'retain-on-failure',
+		storageState: {
+			cookies: [],
+			origins: [
+				{
+					origin: baseURL,
+					localStorage: [{ name: 'wts_hasSeenHowToPlay', value: '1' }]
+				}
+			]
+		}
 	},
 	projects: [
 		{

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/HowToPlay.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/HowToPlay.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	let { onclose }: { onclose: () => void } = $props();
+
+	function handleBackdropClick(evt: MouseEvent) {
+		if (evt.target === evt.currentTarget) {
+			onclose();
+		}
+	}
+
+	function handleKeydown(evt: KeyboardEvent) {
+		if (evt.key === 'Escape') {
+			onclose();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+	onclick={handleBackdropClick}
+	role="presentation"
+	data-testid="how-to-play-modal"
+>
+	<div
+		class="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-3xl border border-white/10 bg-gradient-to-b from-slate-800 to-slate-900 p-8 shadow-2xl"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="how-to-play-title"
+		tabindex="-1"
+	>
+		<button
+			class="absolute top-5 right-5 flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/70 transition hover:border-white/40 hover:bg-white/20 hover:text-white"
+			onclick={onclose}
+			aria-label="Close how to play"
+			data-testid="close-how-to-play"
+		>
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+			</svg>
+		</button>
+
+		<h2 id="how-to-play-title" class="text-xl font-semibold tracking-tight text-white">
+			How to play
+		</h2>
+		<p class="mt-2 text-sm text-slate-300/80">
+			Guess the hidden 5-letter word in 6 tries. Each guess must be a valid word.
+		</p>
+
+		<div class="mt-6 space-y-6">
+			<!-- Tile colour legend -->
+			<section>
+				<h3 class="mb-3 text-xs font-semibold tracking-[0.2em] text-slate-200/60 uppercase">
+					Tile colours
+				</h3>
+				<div class="space-y-3">
+					<div class="flex items-center gap-4">
+						<div
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-emerald-400 bg-emerald-400 text-sm font-semibold text-slate-900"
+							aria-label="Green tile example"
+						>
+							C
+						</div>
+						<p class="text-sm text-slate-200/90">
+							<span class="font-semibold text-emerald-300">Green</span> — the letter is in the word and
+							in the correct position.
+						</p>
+					</div>
+					<div class="flex items-center gap-4">
+						<div
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-amber-300/70 bg-amber-300 text-sm font-semibold text-slate-900"
+							aria-label="Yellow tile example"
+						>
+							R
+						</div>
+						<p class="text-sm text-slate-200/90">
+							<span class="font-semibold text-amber-300">Yellow</span> — the letter is in the word but
+							in the wrong position.
+						</p>
+					</div>
+					<div class="flex items-center gap-4">
+						<div
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/15 bg-white/5 text-sm font-semibold text-white/60"
+							aria-label="Grey tile example"
+						>
+							A
+						</div>
+						<p class="text-sm text-slate-200/90">
+							<span class="font-semibold text-slate-300">Grey</span> — the letter is not in the word at
+							all.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<hr class="border-white/10" />
+
+			<!-- Example word -->
+			<section>
+				<h3 class="mb-3 text-xs font-semibold tracking-[0.2em] text-slate-200/60 uppercase">
+					Example
+				</h3>
+				<div class="flex gap-2" aria-label="Example guess: CRANE">
+					{#each ['C', 'R', 'A', 'N', 'E'] as letter, i (i)}
+						<div
+							class={`flex h-12 w-12 items-center justify-center rounded-xl border text-base font-semibold ${
+								i === 0
+									? 'border-emerald-400 bg-emerald-400 text-slate-900'
+									: i === 1
+										? 'border-amber-300/70 bg-amber-300 text-slate-900'
+										: 'border-white/15 bg-white/5 text-white/60'
+							}`}
+						>
+							{letter}
+						</div>
+					{/each}
+				</div>
+				<p class="mt-3 text-sm text-slate-300/80">
+					<strong class="text-white">C</strong> is correct and in position 1.
+					<strong class="text-white">R</strong> is in the word but not in position 2.
+					<strong class="text-white">A, N, E</strong> are not in the word.
+				</p>
+			</section>
+
+			<hr class="border-white/10" />
+
+			<!-- Hard mode vs Easy mode -->
+			<section>
+				<h3 class="mb-3 text-xs font-semibold tracking-[0.2em] text-slate-200/60 uppercase">
+					Game modes
+				</h3>
+				<div class="space-y-3">
+					<div class="rounded-xl border border-emerald-300/30 bg-emerald-400/5 p-3">
+						<div class="flex items-center gap-2">
+							<span
+								class="rounded-full border border-emerald-300/60 bg-emerald-400/10 px-2 py-0.5 text-xs font-semibold tracking-[0.15em] text-emerald-100 uppercase"
+							>
+								Hard mode
+							</span>
+						</div>
+						<p class="mt-2 text-sm text-slate-300/80">
+							Every subsequent guess must include all green letters in their exact positions and all
+							yellow letters somewhere in the word.
+						</p>
+					</div>
+					<div class="rounded-xl border border-amber-300/30 bg-amber-400/5 p-3">
+						<div class="flex items-center gap-2">
+							<span
+								class="rounded-full border border-amber-300/50 bg-amber-400/10 px-2 py-0.5 text-xs font-semibold tracking-[0.15em] text-amber-50 uppercase"
+							>
+								Easy mode
+							</span>
+						</div>
+						<p class="mt-2 text-sm text-slate-300/80">
+							No letter constraints. You can guess any valid word regardless of previous hints.
+						</p>
+					</div>
+				</div>
+				<p class="mt-3 text-xs text-slate-300/60">
+					You can switch to Easy mode at any point before completing the puzzle — but only for that
+					day's attempt.
+				</p>
+			</section>
+
+			<hr class="border-white/10" />
+
+			<!-- Daily cutoff -->
+			<section>
+				<h3 class="mb-3 text-xs font-semibold tracking-[0.2em] text-slate-200/60 uppercase">
+					Daily cutoff
+				</h3>
+				<p class="text-sm text-slate-300/80">
+					Solve the puzzle before <strong class="text-white">12:00 PM local time</strong> to count toward
+					your streak and leaderboard ranking. Games started after noon are tracked separately as practice
+					rounds and won't affect your stats.
+				</p>
+			</section>
+		</div>
+
+		<button
+			class="mt-8 w-full rounded-2xl bg-emerald-400 py-3 text-sm font-semibold text-slate-900 transition hover:bg-emerald-300"
+			onclick={onclose}
+			data-testid="got-it-button"
+		>
+			Got it — let's play!
+		</button>
+	</div>
+</div>

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/HowToPlay.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/HowToPlay.svelte
@@ -16,7 +16,6 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
 	class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
 	onclick={handleBackdropClick}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
@@ -4,10 +4,13 @@
 	import { auth, bootstrapAuth, signOut } from '$lib/auth/store';
 	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
+	import HowToPlay from '$lib/game/HowToPlay.svelte';
 
 	let { children } = $props();
 	let booting = $state(true);
+	let showHowToPlay = $state(false);
 	const isTestMode = import.meta.env.MODE === 'test';
+	const STORAGE_KEY = 'wts_hasSeenHowToPlay';
 
 	onMount(async () => {
 		if (isTestMode) {
@@ -18,7 +21,20 @@
 
 		await bootstrapAuth();
 		booting = false;
+
+		if (!localStorage.getItem(STORAGE_KEY)) {
+			showHowToPlay = true;
+		}
 	});
+
+	function openHowToPlay() {
+		showHowToPlay = true;
+	}
+
+	function closeHowToPlay() {
+		showHowToPlay = false;
+		localStorage.setItem(STORAGE_KEY, '1');
+	}
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
@@ -37,18 +53,42 @@
 					<div class="text-xs text-slate-200/70">Keep your streaks honest.</div>
 				</div>
 			</div>
-			{#if $auth.user}
-				<nav
-					class="hidden items-center gap-4 text-xs font-semibold tracking-[0.2em] text-slate-200/70 uppercase md:flex"
+			<div class="flex items-center gap-4">
+				{#if $auth.user}
+					<nav
+						class="hidden items-center gap-4 text-xs font-semibold tracking-[0.2em] text-slate-200/70 uppercase md:flex"
+					>
+						<a href={resolve('/')} class="transition hover:text-white">Play</a>
+						<a href={resolve('/stats')} class="transition hover:text-white">Stats</a>
+						<a href={resolve('/leaderboard')} class="transition hover:text-white">Leaderboard</a>
+						{#if $auth.user?.isAdmin}
+							<a href={resolve('/admin')} class="transition hover:text-white">Admin</a>
+						{/if}
+					</nav>
+				{/if}
+				<button
+					class="flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-white/5 text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+					onclick={openHowToPlay}
+					aria-label="How to play"
+					data-testid="open-how-to-play"
 				>
-					<a href={resolve('/')} class="transition hover:text-white">Play</a>
-					<a href={resolve('/stats')} class="transition hover:text-white">Stats</a>
-					<a href={resolve('/leaderboard')} class="transition hover:text-white">Leaderboard</a>
-					{#if $auth.user?.isAdmin}
-						<a href={resolve('/admin')} class="transition hover:text-white">Admin</a>
-					{/if}
-				</nav>
-			{/if}
+					<svg
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						class="h-4 w-4"
+					>
+						<circle cx="12" cy="12" r="10" />
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+						/>
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 17h.01" />
+					</svg>
+				</button>
+			</div>
 			<div class="flex items-center gap-3 text-sm">
 				{#if $auth.user}
 					<div class="hidden text-right sm:block">
@@ -95,3 +135,7 @@
 		{/if}
 	</main>
 </div>
+
+{#if showHowToPlay}
+	<HowToPlay onclose={closeHowToPlay} />
+{/if}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
@@ -11,18 +11,19 @@
 	let showHowToPlay = $state(false);
 	const isTestMode = import.meta.env.MODE === 'test';
 	const STORAGE_KEY = 'wts_hasSeenHowToPlay';
+	const TEST_AUTO_OPEN_KEY = 'wts_enableHowToPlayAutoOpen';
 
 	onMount(async () => {
 		if (isTestMode) {
 			booting = false;
 			void bootstrapAuth();
-			return;
+		} else {
+			await bootstrapAuth();
+			booting = false;
 		}
 
-		await bootstrapAuth();
-		booting = false;
-
-		if (!localStorage.getItem(STORAGE_KEY)) {
+		const autoOpenEnabled = !isTestMode || localStorage.getItem(TEST_AUTO_OPEN_KEY) === '1';
+		if (autoOpenEnabled && !localStorage.getItem(STORAGE_KEY)) {
 			showHowToPlay = true;
 		}
 	});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/how-to-play.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/how-to-play.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+
+const MOCK_USER = {
+	id: '11111111-1111-1111-1111-111111111111',
+	displayName: 'Tester',
+	email: 'tester@example.com',
+	createdOn: '2025-01-01T00:00:00Z',
+	isAdmin: false
+};
+
+const MOCK_GAME_STATE = {
+	puzzleDate: '2025-01-01',
+	cutoffPassed: false,
+	solutionRevealed: false,
+	allowLatePlay: false,
+	wordLength: 5,
+	maxGuesses: 6,
+	isHardMode: true,
+	canGuess: true,
+	attempt: null,
+	solution: null
+};
+
+async function setupRoutes(page: import('@playwright/test').Page) {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(MOCK_USER)
+		});
+	});
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(MOCK_GAME_STATE)
+		});
+	});
+}
+
+test('shows how-to-play modal on first visit when localStorage key is absent', async ({
+	page,
+	context
+}) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+	await expect(page.getByText('How to play')).toBeVisible();
+});
+
+test('does not show modal on revisit after dismissal', async ({ page, context }) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	// Simulate returning visitor by pre-seeding localStorage
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.evaluate(() => localStorage.setItem('wts_hasSeenHowToPlay', '1'));
+	await page.reload({ waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('how-to-play-modal')).not.toBeVisible();
+});
+
+test('closes modal when Close button is clicked and sets localStorage', async ({
+	page,
+	context
+}) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+
+	await page.getByTestId('close-how-to-play').click();
+	await expect(page.getByTestId('how-to-play-modal')).not.toBeVisible();
+
+	const stored = await page.evaluate(() => localStorage.getItem('wts_hasSeenHowToPlay'));
+	expect(stored).toBe('1');
+});
+
+test('closes modal when Got it button is clicked', async ({ page, context }) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+
+	await page.getByTestId('got-it-button').click();
+	await expect(page.getByTestId('how-to-play-modal')).not.toBeVisible();
+});
+
+test('closes modal when Escape key is pressed', async ({ page, context }) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+
+	await page.keyboard.press('Escape');
+	await expect(page.getByTestId('how-to-play-modal')).not.toBeVisible();
+});
+
+test('help icon in header opens the modal', async ({ page, context }) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	// Dismiss the auto-open first
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.evaluate(() => localStorage.setItem('wts_hasSeenHowToPlay', '1'));
+	await page.reload({ waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('how-to-play-modal')).not.toBeVisible();
+
+	await page.getByTestId('open-how-to-play').click();
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+});
+
+test('modal explains tile colours and game modes', async ({ page, context }) => {
+	await context.clearCookies();
+	await setupRoutes(page);
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+
+	// Tile colour explanations
+	await expect(page.getByText('Green')).toBeVisible();
+	await expect(page.getByText('Yellow')).toBeVisible();
+	await expect(page.getByText('Grey')).toBeVisible();
+
+	// Game mode explanations
+	await expect(page.getByText('Hard mode')).toBeVisible();
+	await expect(page.getByText('Easy mode')).toBeVisible();
+
+	// Daily cutoff
+	await expect(page.getByText('12:00 PM local time')).toBeVisible();
+});

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/how-to-play.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/how-to-play.spec.ts
@@ -22,6 +22,9 @@ const MOCK_GAME_STATE = {
 };
 
 async function setupRoutes(page: import('@playwright/test').Page) {
+	await page.addInitScript(() => {
+		localStorage.setItem('wts_enableHowToPlayAutoOpen', '1');
+	});
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
 			status: 200,
@@ -129,17 +132,18 @@ test('modal explains tile colours and game modes', async ({ page, context }) => 
 
 	await page.goto('/', { waitUntil: 'domcontentloaded' });
 	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
-	await expect(page.getByTestId('how-to-play-modal')).toBeVisible();
+	const modal = page.getByTestId('how-to-play-modal');
+	await expect(modal).toBeVisible();
 
 	// Tile colour explanations
-	await expect(page.getByText('Green')).toBeVisible();
-	await expect(page.getByText('Yellow')).toBeVisible();
-	await expect(page.getByText('Grey')).toBeVisible();
+	await expect(modal.getByText('Green', { exact: true })).toBeVisible();
+	await expect(modal.getByText('Yellow', { exact: true })).toBeVisible();
+	await expect(modal.getByText('Grey', { exact: true })).toBeVisible();
 
 	// Game mode explanations
-	await expect(page.getByText('Hard mode')).toBeVisible();
-	await expect(page.getByText('Easy mode')).toBeVisible();
+	await expect(modal.getByText('Hard mode', { exact: true })).toBeVisible();
+	await expect(modal.getByText('Easy mode', { exact: true })).toBeVisible();
 
 	// Daily cutoff
-	await expect(page.getByText('12:00 PM local time')).toBeVisible();
+	await expect(modal.getByText('12:00 PM local time')).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Adds a `HowToPlay.svelte` modal component explaining tile colours (green/yellow/grey), hard vs easy mode, and the 12:00 PM daily cutoff
- Modal auto-opens once per browser via `localStorage` key `wts_hasSeenHowToPlay`
- Dismissible via close button (✕), "Got it — let's play!" button, clicking the backdrop, or pressing `Escape`
- A `?` help icon is added to the site header so users can re-open the modal at any time

## Test plan

- [ ] `tests/ui/how-to-play.spec.ts` — 6 Playwright UI tests covering: first-visit auto-open, repeat-visit suppression, close button, Got it button, Escape key, and help icon re-open
- [ ] All 37 Vitest unit tests continue to pass
- [ ] `npm run format && npm run lint` clean

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)