### PR TITLE
Add colorblind / high-contrast mode (#29)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/colorMode.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/colorMode.spec.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('colorMode store', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it('defaults to false when localStorage has no value', async () => {
+		const { colorMode } = await import('./colorMode');
+		colorMode.init();
+		expect(get(colorMode)).toBe(false);
+	});
+
+	it('reads true from localStorage when key is set to 1', async () => {
+		localStorage.setItem('wts_highContrastMode', '1');
+		const { colorMode } = await import('./colorMode');
+		colorMode.init();
+		expect(get(colorMode)).toBe(true);
+	});
+
+	it('toggle flips the value and persists to localStorage', async () => {
+		const { colorMode } = await import('./colorMode');
+		colorMode.init();
+		expect(get(colorMode)).toBe(false);
+
+		colorMode.toggle();
+		expect(get(colorMode)).toBe(true);
+		expect(localStorage.getItem('wts_highContrastMode')).toBe('1');
+
+		colorMode.toggle();
+		expect(get(colorMode)).toBe(false);
+		expect(localStorage.getItem('wts_highContrastMode')).toBe('0');
+	});
+});

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/colorMode.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/colorMode.ts
@@ -1,0 +1,25 @@
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'wts_highContrastMode';
+
+function createColorModeStore() {
+	let current = false;
+	const { subscribe, set } = writable(false);
+
+	return {
+		subscribe,
+		init() {
+			if (typeof localStorage !== 'undefined') {
+				current = localStorage.getItem(STORAGE_KEY) === '1';
+				set(current);
+			}
+		},
+		toggle() {
+			current = !current;
+			localStorage.setItem(STORAGE_KEY, current ? '1' : '0');
+			set(current);
+		}
+	};
+}
+
+export const colorMode = createColorModeStore();

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import { auth, bootstrapAuth, signOut } from '$lib/auth/store';
+	import { colorMode } from '$lib/game/colorMode';
 	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 
@@ -10,6 +11,8 @@
 	const isTestMode = import.meta.env.MODE === 'test';
 
 	onMount(async () => {
+		colorMode.init();
+
 		if (isTestMode) {
 			booting = false;
 			void bootstrapAuth();
@@ -50,6 +53,25 @@
 				</nav>
 			{/if}
 			<div class="flex items-center gap-3 text-sm">
+				<button
+					class={`flex h-8 w-8 items-center justify-center rounded-full border transition ${$colorMode ? 'border-blue-400/60 bg-blue-400/15 text-blue-300 hover:border-blue-400/80 hover:bg-blue-400/25' : 'border-white/20 bg-white/5 text-white/60 hover:border-white/40 hover:bg-white/10 hover:text-white'}`}
+					onclick={() => colorMode.toggle()}
+					aria-label={$colorMode ? 'Disable high-contrast mode' : 'Enable high-contrast mode'}
+					aria-pressed={$colorMode}
+					data-testid="toggle-high-contrast"
+					title={$colorMode ? 'High-contrast: on' : 'High-contrast: off'}
+				>
+					<svg
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						class="h-4 w-4"
+					>
+						<circle cx="12" cy="12" r="10" />
+						<path d="M12 2a10 10 0 0 1 0 20V2z" fill="currentColor" stroke="none" />
+					</svg>
+				</button>
 				{#if $auth.user}
 					<div class="hidden text-right sm:block">
 						<div class="font-semibold">{$auth.user.displayName}</div>

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/game/confetti';
 	import { getKeyboardLetterState } from '$lib/game/keyboard';
 	import type { GameStateResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
+	import { colorMode } from '$lib/game/colorMode';
 	import { onMount, tick } from 'svelte';
 
 	let checking = true;
@@ -104,6 +105,7 @@
 	$: guessInputLocked = !state || !state.canGuess || submitting;
 	$: announcement = error ?? message;
 	$: announcementIsError = error !== null;
+	$: highContrast = $colorMode;
 
 	async function loadEverything() {
 		await loadState();
@@ -251,10 +253,14 @@
 		const base =
 			'flex h-14 w-14 items-center justify-center rounded-xl border text-lg font-semibold transition';
 		if (result === 'Correct') {
-			return `${base} border-emerald-400 bg-emerald-400 text-slate-900 shadow-lg`;
+			return highContrast
+				? `${base} border-orange-500 bg-orange-500 text-white shadow-lg`
+				: `${base} border-emerald-400 bg-emerald-400 text-slate-900 shadow-lg`;
 		}
 		if (result === 'Present') {
-			return `${base} border-amber-300/70 bg-amber-300 text-slate-900 shadow`;
+			return highContrast
+				? `${base} border-blue-400 bg-blue-400 text-white shadow`
+				: `${base} border-amber-300/70 bg-amber-300 text-slate-900 shadow`;
 		}
 		if (result === 'Absent') {
 			return `${base} border-white/15 bg-white/5 text-white/60`;
@@ -287,10 +293,14 @@
 			'flex h-11 items-center justify-center rounded-xl border px-3 text-sm font-semibold uppercase transition';
 		const stateKey = keyState(letter);
 		if (stateKey === 'Correct') {
-			return `${base} border-emerald-400 bg-emerald-400 text-slate-900`;
+			return highContrast
+				? `${base} border-orange-500 bg-orange-500 text-white`
+				: `${base} border-emerald-400 bg-emerald-400 text-slate-900`;
 		}
 		if (stateKey === 'Present') {
-			return `${base} border-amber-300/70 bg-amber-300 text-slate-900`;
+			return highContrast
+				? `${base} border-blue-400 bg-blue-400 text-white`
+				: `${base} border-amber-300/70 bg-amber-300 text-slate-900`;
 		}
 		if (stateKey === 'Absent') {
 			return `${base} border-slate-500/70 bg-slate-600 text-slate-100`;
@@ -381,6 +391,7 @@
 	<div class="mx-auto grid max-w-6xl gap-6">
 		<section
 			class="relative rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-2xl"
+			data-high-contrast={highContrast}
 		>
 			{#if showConfetti}
 				<div class="confetti-layer" data-testid="confetti">
@@ -624,6 +635,19 @@
 		--end-bg: rgba(255, 255, 255, 0.08);
 		--end-border: rgba(255, 255, 255, 0.2);
 		--end-text: rgba(255, 255, 255, 0.6);
+	}
+
+	/* High-contrast overrides */
+	:global([data-high-contrast='true'] .reveal-correct) {
+		--end-bg: #f97316;
+		--end-border: #f97316;
+		--end-text: #ffffff;
+	}
+
+	:global([data-high-contrast='true'] .reveal-present) {
+		--end-bg: #60a5fa;
+		--end-border: #60a5fa;
+		--end-text: #ffffff;
 	}
 
 	@keyframes reveal-flip {

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/colorblind-mode.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/colorblind-mode.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test';
+
+const MOCK_USER = {
+	id: '11111111-1111-1111-1111-111111111111',
+	displayName: 'Tester',
+	email: 'tester@example.com',
+	createdOn: '2025-01-01T00:00:00Z',
+	isAdmin: false
+};
+
+const MOCK_GAME_STATE = {
+	puzzleDate: '2025-01-01',
+	cutoffPassed: false,
+	solutionRevealed: false,
+	allowLatePlay: false,
+	wordLength: 5,
+	maxGuesses: 6,
+	isHardMode: true,
+	canGuess: true,
+	attempt: {
+		attemptId: '22222222-2222-2222-2222-222222222222',
+		status: 'InProgress',
+		isAfterReveal: false,
+		createdOn: '2025-01-01T00:00:00Z',
+		completedOn: null,
+		guesses: [
+			{
+				guessId: 'gggg-1',
+				guessNumber: 1,
+				guessWord: 'CRANE',
+				feedback: [
+					{ position: 0, letter: 'C', result: 'Correct' },
+					{ position: 1, letter: 'R', result: 'Present' },
+					{ position: 2, letter: 'A', result: 'Absent' },
+					{ position: 3, letter: 'N', result: 'Absent' },
+					{ position: 4, letter: 'E', result: 'Absent' }
+				]
+			}
+		]
+	},
+	solution: null
+};
+
+async function setupRoutes(page: import('@playwright/test').Page) {
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(MOCK_USER)
+		});
+	});
+	await page.route('**/api/game/state', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(MOCK_GAME_STATE)
+		});
+	});
+}
+
+test('high-contrast toggle is visible in the header', async ({ page }) => {
+	await setupRoutes(page);
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('toggle-high-contrast')).toBeVisible();
+});
+
+test('toggling high-contrast applies orange color to correct tiles', async ({ page }) => {
+	await setupRoutes(page);
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	// Default: correct tile should be emerald (green)
+	const correctTile = page.locator('[role="gridcell"]').first();
+	await expect(correctTile).toHaveClass(/bg-emerald-400/);
+
+	// Enable high-contrast
+	await page.getByTestId('toggle-high-contrast').click();
+
+	// Now the correct tile should be orange
+	await expect(correctTile).toHaveClass(/bg-orange-500/);
+});
+
+test('toggling high-contrast applies blue color to present tiles', async ({ page }) => {
+	await setupRoutes(page);
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	// Default: present tile uses amber
+	const presentTile = page.locator('[role="gridcell"]').nth(1);
+	await expect(presentTile).toHaveClass(/bg-amber-300/);
+
+	// Enable high-contrast
+	await page.getByTestId('toggle-high-contrast').click();
+	await expect(presentTile).toHaveClass(/bg-blue-400/);
+});
+
+test('high-contrast preference persists across page reloads', async ({ page }) => {
+	await setupRoutes(page);
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	// Enable high-contrast
+	await page.getByTestId('toggle-high-contrast').click();
+	expect(await page.evaluate(() => localStorage.getItem('wts_highContrastMode'))).toBe('1');
+
+	// Reload and check it's still applied
+	await page.reload({ waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	const correctTile = page.locator('[role="gridcell"]').first();
+	await expect(correctTile).toHaveClass(/bg-orange-500/);
+});
+
+test('toggling off restores standard colours', async ({ page }) => {
+	await setupRoutes(page);
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	const correctTile = page.locator('[role="gridcell"]').first();
+
+	// Turn on then off
+	await page.getByTestId('toggle-high-contrast').click();
+	await expect(correctTile).toHaveClass(/bg-orange-500/);
+
+	await page.getByTestId('toggle-high-contrast').click();
+	await expect(correctTile).toHaveClass(/bg-emerald-400/);
+});


### PR DESCRIPTION
## Summary

- Adds a persistent high-contrast mode toggle (half-circle icon) in the site header
- When enabled, tile and keyboard colours switch from green/amber to **orange/blue** — matching the original Wordle's accessibility palette, covering deuteranopia and protanopia
- Preference persists in `localStorage` (`wts_highContrastMode`) across page reloads
- The tile reveal flip animation is also updated via a `data-high-contrast` CSS attribute override
- New `colorMode` Svelte store (`src/lib/game/colorMode.ts`) backed by localStorage

## Test plan

- [ ] `tests/ui/colorblind-mode.spec.ts` — 5 Playwright UI tests: toggle visibility, orange correct tiles, blue present tiles, persistence across reload, toggle off restores standard colours
- [ ] `src/lib/game/colorMode.spec.ts` — 3 Vitest unit tests for the store: default false, reads from localStorage, toggle persists
- [ ] All 40 Vitest unit tests pass
- [ ] `npm run format && npm run lint` clean

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)