### PR TITLE
Fix mobile UX: responsive keyboard and suppress native soft keyboard (#38)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -445,7 +445,9 @@
 				</div>
 			{:else if state}
 				<div class="mt-6">
-					<div class="space-y-4 rounded-2xl border border-white/10 bg-black/20 p-6 shadow-inner">
+					<div
+						class="space-y-4 rounded-2xl border border-white/10 bg-black/20 p-4 pb-36 shadow-inner sm:p-6"
+					>
 						<div class="grid grid-rows-6 gap-1.5" role="grid" aria-label="Wordle board">
 							{#each Array(state.maxGuesses).keys() as rowIndex (rowIndex)}
 								<div
@@ -504,7 +506,11 @@
 							</div>
 						{/if}
 
-						<div class="space-y-2 pt-3 sm:space-y-3" role="group" aria-label="On-screen keyboard">
+						<div
+							class="fixed right-0 bottom-0 left-0 z-30 space-y-2 border-t border-white/10 bg-slate-950/95 px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] shadow-2xl backdrop-blur sm:static sm:space-y-3 sm:border-0 sm:bg-transparent sm:px-0 sm:pt-3 sm:pb-0 sm:shadow-none sm:backdrop-blur-none"
+							role="group"
+							aria-label="On-screen keyboard"
+						>
 							{#each keyboardRows as row, rowIndex (rowIndex)}
 								<div class="flex w-full items-center justify-center gap-1 sm:gap-2">
 									{#if rowIndex === 2}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -249,7 +249,7 @@
 
 	function tileClass(result: LetterResult | null) {
 		const base =
-			'flex h-14 w-14 items-center justify-center rounded-xl border text-lg font-semibold transition';
+			'flex h-14 w-full items-center justify-center rounded-xl border text-lg font-semibold transition';
 		if (result === 'Correct') {
 			return `${base} border-emerald-400 bg-emerald-400 text-slate-900 shadow-lg`;
 		}
@@ -284,7 +284,7 @@
 
 	function keyClass(letter: string) {
 		const base =
-			'flex h-11 items-center justify-center rounded-xl border px-3 text-sm font-semibold uppercase transition';
+			'flex h-10 items-center justify-center rounded-xl border px-2 text-sm font-semibold uppercase transition sm:h-11 sm:px-3';
 		const stateKey = keyState(letter);
 		if (stateKey === 'Correct') {
 			return `${base} border-emerald-400 bg-emerald-400 text-slate-900`;
@@ -380,7 +380,7 @@
 {:else if $auth.user}
 	<div class="mx-auto grid max-w-6xl gap-6">
 		<section
-			class="relative rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-2xl"
+			class="relative rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-4 shadow-2xl sm:p-8"
 		>
 			{#if showConfetti}
 				<div class="confetti-layer" data-testid="confetti">
@@ -436,7 +436,7 @@
 							{#each Array(state.maxGuesses).keys() as rowIndex (rowIndex)}
 								<div
 									class={`grid justify-center gap-1.5${shakingRow === rowIndex ? ' animate-shake' : ''}`}
-									style={`grid-template-columns: repeat(${state.wordLength}, 3.5rem);`}
+									style={`grid-template-columns: repeat(${state.wordLength}, min(3.5rem, calc((min(100vw, 640px) - 8rem) / ${state.wordLength})));`}
 									data-testid={`board-row-${rowIndex}`}
 									role="row"
 									aria-label={`Guess row ${rowIndex + 1}`}
@@ -490,13 +490,14 @@
 							</div>
 						{/if}
 
-						<div class="space-y-3 pt-3" role="group" aria-label="On-screen keyboard">
+						<div class="space-y-2 pt-3 sm:space-y-3" role="group" aria-label="On-screen keyboard">
 							{#each keyboardRows as row, rowIndex (rowIndex)}
-								<div class="flex items-center justify-center gap-2">
+								<div class="flex items-center justify-center gap-1 sm:gap-2">
 									{#if rowIndex === 2}
 										<button
-											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
+											class="flex h-11 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30 sm:h-12 sm:px-4"
 											onclick={removeLetter}
+											onpointerdown={(e) => e.preventDefault()}
 											disabled={guessInputLocked}
 											data-testid="remove-letter"
 											aria-label="Remove letter"
@@ -508,6 +509,7 @@
 										<button
 											class={keyClass(letter)}
 											onclick={() => pushLetter(letter)}
+											onpointerdown={(e) => e.preventDefault()}
 											disabled={guessInputLocked}
 											data-testid={`keyboard-key-${letter}`}
 											data-state={(keyState(letter) ?? 'unused').toLowerCase()}
@@ -517,8 +519,9 @@
 									{/each}
 									{#if rowIndex === 2}
 										<button
-											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
+											class="flex h-11 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30 sm:h-12 sm:px-4"
 											onclick={submitFromKeyboard}
+											onpointerdown={(e) => e.preventDefault()}
 											disabled={guessInputLocked}
 											data-testid="submit-guess"
 											aria-label="Submit guess"

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/mobile-keyboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/mobile-keyboard.spec.ts
@@ -3,7 +3,8 @@ import { expect, test } from '@playwright/test';
 test('mobile layout keeps board in viewport and submits with on-screen keyboard', async ({
 	page
 }) => {
-	await page.setViewportSize({ width: 375, height: 760 });
+	const viewport = { width: 375, height: 640 };
+	await page.setViewportSize(viewport);
 
 	await page.route('**/api/Auth/me', async (route) => {
 		await route.fulfill({
@@ -87,7 +88,15 @@ test('mobile layout keeps board in viewport and submits with on-screen keyboard'
 	const rowBox = await firstRow.boundingBox();
 	expect(rowBox).not.toBeNull();
 	expect(rowBox!.x).toBeGreaterThanOrEqual(0);
-	expect(rowBox!.x + rowBox!.width).toBeLessThanOrEqual(375);
+	expect(rowBox!.x + rowBox!.width).toBeLessThanOrEqual(viewport.width);
+
+	const keyboard = page.getByRole('group', { name: 'On-screen keyboard' });
+	const keyboardBox = await keyboard.boundingBox();
+	expect(keyboardBox).not.toBeNull();
+	expect(keyboardBox!.x).toBeGreaterThanOrEqual(0);
+	expect(keyboardBox!.x + keyboardBox!.width).toBeLessThanOrEqual(viewport.width);
+	expect(keyboardBox!.y + keyboardBox!.height).toBeGreaterThanOrEqual(viewport.height - 16);
+	expect(keyboardBox!.y + keyboardBox!.height).toBeLessThanOrEqual(viewport.height);
 
 	for (const letter of ['C', 'R', 'A', 'N', 'E']) {
 		await page.getByTestId(`keyboard-key-${letter}`).click();


### PR DESCRIPTION
## Summary

- Tile grid now uses responsive sizing so tiles shrink proportionally on narrow viewports instead of overflowing
- On-screen keyboard rows and keys use smaller mobile spacing and sizing
- Section padding is reduced on mobile to maximize space for the board
- Mobile keyboard is anchored at the bottom of the viewport and remains visible on small screens
- Keyboard buttons suppress focus on pointer down to avoid native soft-keyboard popups on touch devices

## Test plan

- [x] `npm run test -- --run`
- [x] `npm run lint`
- [x] Targeted Playwright coverage for mobile keyboard layout, keyboard highlights, high-contrast mode, and how-to-play modal
- [x] `git diff --check`

Closes #38

🤖 Generated with Codex