### PR TITLE
Add admin player list pagination and search (#33)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -13,14 +13,18 @@ namespace Wordle.TrackerSupreme.Api.Controllers;
 public class AdminController(IAdminService adminService) : ControllerBase
 {
     [HttpGet("players")]
-    public async Task<ActionResult<IReadOnlyList<AdminPlayerSummaryResponse>>> GetPlayers(CancellationToken cancellationToken)
+    public async Task<ActionResult<AdminPlayersPageResponse>> GetPlayers(
+        [FromQuery] string? search,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
     {
-        var players = await adminService.GetPlayers(cancellationToken);
-        var response = players
-            .OrderBy(player => player.DisplayName)
-            .Select(MapSummary)
-            .ToList();
-        return Ok(response);
+        if (page < 1) page = 1;
+        if (pageSize is < 1 or > 100) pageSize = 20;
+
+        var (players, totalCount) = await adminService.GetPlayersPage(search, page, pageSize, cancellationToken);
+        var entries = players.Select(MapSummary).ToList();
+        return Ok(new AdminPlayersPageResponse(entries, totalCount, page, pageSize));
     }
 
     [HttpGet("players/{playerId:guid}")]

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -19,8 +19,15 @@ public class AdminController(IAdminService adminService) : ControllerBase
         [FromQuery] int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
-        if (page < 1) page = 1;
-        if (pageSize is < 1 or > 100) pageSize = 20;
+        if (page < 1)
+        {
+            page = 1;
+        }
+
+        if (pageSize is < 1 or > 100)
+        {
+            pageSize = 20;
+        }
 
         var (players, totalCount) = await adminService.GetPlayersPage(search, page, pageSize, cancellationToken);
         var entries = players.Select(MapSummary).ToList();

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminPlayersPageResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminPlayersPageResponse.cs
@@ -1,0 +1,7 @@
+namespace Wordle.TrackerSupreme.Api.Models.Admin;
+
+public record AdminPlayersPageResponse(
+    IReadOnlyList<AdminPlayerSummaryResponse> Players,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Admin/AdminService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Admin/AdminService.cs
@@ -23,6 +23,12 @@ public class AdminService(
     public async Task<IReadOnlyList<Player>> GetPlayers(CancellationToken cancellationToken)
         => await _playerRepository.GetPlayersWithAttempts(cancellationToken);
 
+    public async Task<(IReadOnlyList<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken)
+    {
+        var (players, totalCount) = await _playerRepository.GetPlayersPage(search, page, pageSize, cancellationToken);
+        return (players, totalCount);
+    }
+
     public Task<Player?> GetPlayer(Guid playerId, CancellationToken cancellationToken)
         => _playerRepository.GetPlayerWithAttemptsAndGuesses(playerId, cancellationToken);
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IPlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IPlayerRepository.cs
@@ -10,6 +10,7 @@ public interface IPlayerRepository
     Task<Player?> GetPlayerWithAttemptsAndGuesses(Guid playerId, CancellationToken cancellationToken);
     Task<List<Player>> GetPlayers(CancellationToken cancellationToken);
     Task<List<Player>> GetPlayersWithAttempts(CancellationToken cancellationToken);
+    Task<(List<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken);
     Task AddPlayer(Player player, CancellationToken cancellationToken);
     Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken);
     Task<bool> IsEmailTaken(string email, Guid? excludePlayerId, CancellationToken cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/IAdminService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/IAdminService.cs
@@ -5,6 +5,7 @@ namespace Wordle.TrackerSupreme.Domain.Services;
 public interface IAdminService
 {
     Task<IReadOnlyList<Player>> GetPlayers(CancellationToken cancellationToken);
+    Task<(IReadOnlyList<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken);
     Task<Player?> GetPlayer(Guid playerId, CancellationToken cancellationToken);
     Task<Player> UpdatePlayerProfile(Guid playerId, string displayName, string email, CancellationToken cancellationToken);
     Task<Player> ResetPassword(Guid playerId, string newPassword, CancellationToken cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/PlayerRepository.cs
@@ -47,6 +47,31 @@ public class PlayerRepository(WordleTrackerSupremeDbContext dbContext) : IPlayer
                 .ThenInclude(a => a.Guesses)
             .ToListAsync(cancellationToken);
 
+    public async Task<(List<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken)
+    {
+        var query = dbContext.Players
+            .Include(p => p.Attempts)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var term = search.Trim().ToLower();
+            query = query.Where(p =>
+                p.DisplayName.ToLower().Contains(term) ||
+                p.Email.ToLower().Contains(term));
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var players = await query
+            .OrderBy(p => p.DisplayName)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (players, totalCount);
+    }
+
     public Task<bool> IsDisplayNameTaken(string displayName, Guid? excludePlayerId, CancellationToken cancellationToken)
     {
         return dbContext.Players.AnyAsync(

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminServiceTests.cs
@@ -240,6 +240,53 @@ public class AdminServiceTests
         gameRepo.Guesses.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetPlayersPage_returns_paged_results_matching_search()
+    {
+        var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };
+        var validator = new FakeWordValidator([]);
+        var guessService = new GuessEvaluationService(options, validator);
+        var gameRepo = new FakeGameRepository();
+        var passwordHasher = new PasswordHasher<Player>();
+
+        var players = new List<Player>
+        {
+            new() { Id = Guid.NewGuid(), DisplayName = "Alice", Email = "alice@example.com", PasswordHash = "x" },
+            new() { Id = Guid.NewGuid(), DisplayName = "Bob", Email = "bob@example.com", PasswordHash = "x" },
+            new() { Id = Guid.NewGuid(), DisplayName = "Charlie", Email = "charlie@example.com", PasswordHash = "x" }
+        };
+        var playerRepo = new FakeAdminPlayerRepository(players);
+        var service = new AdminService(playerRepo, gameRepo, guessService, passwordHasher, options);
+
+        var (paged, total) = await service.GetPlayersPage("ali", 1, 10, CancellationToken.None);
+
+        total.Should().Be(1);
+        paged.Should().ContainSingle(p => p.DisplayName == "Alice");
+    }
+
+    [Fact]
+    public async Task GetPlayersPage_paginates_correctly()
+    {
+        var options = new GameOptions { WordLength = 5, MaxGuesses = 6 };
+        var validator = new FakeWordValidator([]);
+        var guessService = new GuessEvaluationService(options, validator);
+        var gameRepo = new FakeGameRepository();
+        var passwordHasher = new PasswordHasher<Player>();
+
+        var players = Enumerable.Range(1, 25)
+            .Select(i => new Player { Id = Guid.NewGuid(), DisplayName = $"Player{i:D2}", Email = $"p{i}@e.com", PasswordHash = "x" })
+            .ToList();
+        var playerRepo = new FakeAdminPlayerRepository(players);
+        var service = new AdminService(playerRepo, gameRepo, guessService, passwordHasher, options);
+
+        var (page1, total) = await service.GetPlayersPage(null, 1, 20, CancellationToken.None);
+        var (page2, _) = await service.GetPlayersPage(null, 2, 20, CancellationToken.None);
+
+        total.Should().Be(25);
+        page1.Should().HaveCount(20);
+        page2.Should().HaveCount(5);
+    }
+
     private sealed class FakeAdminPlayerRepository : IPlayerRepository
     {
         private readonly List<Player> _players;
@@ -295,6 +342,19 @@ public class AdminServiceTests
         {
             return Task.FromResult(_players.Any(player =>
                 player.Email == email && (excludePlayerId == null || player.Id != excludePlayerId)));
+        }
+
+        public Task<(List<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken)
+        {
+            var query = _players.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                var term = search.Trim().ToLower();
+                query = query.Where(p => p.DisplayName.ToLower().Contains(term) || p.Email.ToLower().Contains(term));
+            }
+            var all = query.OrderBy(p => p.DisplayName).ToList();
+            var paged = all.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            return Task.FromResult((paged, all.Count));
         }
 
         public Task SaveChanges(CancellationToken cancellationToken)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AuthControllerTests.cs
@@ -215,6 +215,13 @@ public class AuthControllerTests
             => Task.FromResult(Players.Any(p =>
                 p.Email == email && (excludePlayerId == null || p.Id != excludePlayerId)));
 
+        public Task<(List<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken ct)
+        {
+            var all = Players.OrderBy(p => p.DisplayName).ToList();
+            var paged = all.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            return Task.FromResult((paged, all.Count));
+        }
+
         public Task SaveChanges(CancellationToken ct) => Task.CompletedTask;
     }
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
@@ -327,6 +327,13 @@ public class StatsControllerTests
                 player.Email == email && (excludePlayerId == null || player.Id != excludePlayerId)));
         }
 
+        public Task<(List<Player> Players, int TotalCount)> GetPlayersPage(string? search, int page, int pageSize, CancellationToken cancellationToken)
+        {
+            var all = _players.OrderBy(p => p.DisplayName).ToList();
+            var paged = all.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            return Task.FromResult((paged, all.Count));
+        }
+
         public Task SaveChanges(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -133,31 +133,49 @@
 						"content": {
 							"text/plain": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/AdminPlayerSummaryResponse"
-									}
+									"$ref": "#/components/schemas/AdminPlayersPageResponse"
 								}
 							},
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/AdminPlayerSummaryResponse"
-									}
+									"$ref": "#/components/schemas/AdminPlayersPageResponse"
 								}
 							},
 							"text/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/AdminPlayerSummaryResponse"
-									}
+									"$ref": "#/components/schemas/AdminPlayersPageResponse"
 								}
 							}
 						}
 					}
-				}
+				},
+				"parameters": [
+					{
+						"name": "search",
+						"in": "query",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "page",
+						"in": "query",
+						"schema": {
+							"type": "integer",
+							"format": "int32",
+							"default": 1
+						}
+					},
+					{
+						"name": "pageSize",
+						"in": "query",
+						"schema": {
+							"type": "integer",
+							"format": "int32",
+							"default": 20
+						}
+					}
+				]
 			}
 		},
 		"/api/Admin/players/{playerId}": {
@@ -1358,6 +1376,32 @@
 					}
 				},
 				"additionalProperties": false
+			},
+			"AdminPlayersPageResponse": {
+				"type": "object",
+				"properties": {
+					"players": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/AdminPlayerSummaryResponse"
+						},
+						"nullable": true
+					},
+					"totalCount": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"page": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"pageSize": {
+						"type": "integer",
+						"format": "int32"
+					}
+				},
+				"additionalProperties": false,
+				"required": ["totalCount", "page", "pageSize"]
 			}
 		},
 		"securitySchemes": {

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/index.ts
@@ -10,6 +10,7 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 export type { AdminPlayerAttemptResponse } from './models/AdminPlayerAttemptResponse';
 export type { AdminPlayerDetailResponse } from './models/AdminPlayerDetailResponse';
 export type { AdminPlayerSummaryResponse } from './models/AdminPlayerSummaryResponse';
+export type { AdminPlayersPageResponse } from './models/AdminPlayersPageResponse';
 export type { AdminResetPasswordRequest } from './models/AdminResetPasswordRequest';
 export type { AdminSetAdminStatusRequest } from './models/AdminSetAdminStatusRequest';
 export type { AdminUpdateAttemptRequest } from './models/AdminUpdateAttemptRequest';

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/AdminPlayersPageResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/AdminPlayersPageResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AdminPlayerSummaryResponse } from './AdminPlayerSummaryResponse';
+export type AdminPlayersPageResponse = {
+	players?: Array<AdminPlayerSummaryResponse> | null;
+	totalCount?: number;
+	page?: number;
+	pageSize?: number;
+};

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AdminService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/AdminService.ts
@@ -5,6 +5,7 @@
 import type { AdminPlayerAttemptResponse } from '../models/AdminPlayerAttemptResponse';
 import type { AdminPlayerDetailResponse } from '../models/AdminPlayerDetailResponse';
 import type { AdminPlayerSummaryResponse } from '../models/AdminPlayerSummaryResponse';
+import type { AdminPlayersPageResponse } from '../models/AdminPlayersPageResponse';
 import type { AdminResetPasswordRequest } from '../models/AdminResetPasswordRequest';
 import type { AdminSetAdminStatusRequest } from '../models/AdminSetAdminStatusRequest';
 import type { AdminUpdateAttemptRequest } from '../models/AdminUpdateAttemptRequest';
@@ -14,13 +15,26 @@ import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class AdminService {
 	/**
-	 * @returns AdminPlayerSummaryResponse OK
+	 * @returns AdminPlayersPageResponse OK
 	 * @throws ApiError
 	 */
-	public static getApiAdminPlayers(): CancelablePromise<Array<AdminPlayerSummaryResponse>> {
+	public static getApiAdminPlayers({
+		search,
+		page,
+		pageSize
+	}: {
+		search?: string;
+		page?: number;
+		pageSize?: number;
+	} = {}): CancelablePromise<AdminPlayersPageResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
-			url: '/api/Admin/players'
+			url: '/api/Admin/players',
+			query: {
+				search,
+				page,
+				pageSize
+			}
 		});
 	}
 	/**

--- a/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
@@ -57,7 +57,11 @@
 	let players = $state<AdminPlayerSummary[]>([]);
 	let selectedPlayer = $state<AdminPlayerDetail | null>(null);
 	let query = $state('');
-	let filteredPlayers = $state<AdminPlayerSummary[]>([]);
+	let page = $state(1);
+	const pageSize = 20;
+	let totalCount = $state(0);
+	let totalPages = $derived(Math.max(1, Math.ceil(totalCount / pageSize)));
+	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	let displayNameDraft = $state('');
 	let emailDraft = $state('');
@@ -82,19 +86,19 @@
 	);
 	let passwordValidationError = $derived(getAdminPasswordValidationError(passwordDraft));
 
-	$effect(() => {
-		const term = query.trim().toLowerCase();
-		if (!term) {
-			filteredPlayers = players;
-			return;
-		}
+	function handleSearchInput() {
+		if (searchTimeout) clearTimeout(searchTimeout);
+		searchTimeout = setTimeout(() => {
+			page = 1;
+			void loadPlayers();
+		}, 300);
+	}
 
-		filteredPlayers = players.filter((player) => {
-			return (
-				player.displayName.toLowerCase().includes(term) || player.email.toLowerCase().includes(term)
-			);
-		});
-	});
+	function goToPage(newPage: number) {
+		if (newPage < 1 || newPage > totalPages || loading) return;
+		page = newPage;
+		void loadPlayers();
+	}
 
 	function formatDate(value: string) {
 		const date = new Date(value);
@@ -140,8 +144,13 @@
 		loading = true;
 		error = null;
 		try {
-			const response = await AdminService.getApiAdminPlayers();
-			players = response.map(normalizeSummary);
+			const response = await AdminService.getApiAdminPlayers({
+				search: query.trim() || undefined,
+				page,
+				pageSize
+			});
+			players = (response.players ?? []).map(normalizeSummary);
+			totalCount = response.totalCount ?? 0;
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Unable to load admin roster.';
 		} finally {
@@ -453,23 +462,26 @@
 			<div class="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-xl">
 				<div class="flex items-center justify-between">
 					<h2 class="text-sm font-semibold tracking-[0.2em] text-slate-200/70 uppercase">Roster</h2>
-					<span class="text-xs text-slate-200/60">{players.length} players</span>
+					<span class="text-xs text-slate-200/60" data-testid="admin-player-count"
+						>{totalCount} players</span
+					>
 				</div>
 				<div class="mt-4">
 					<input
 						class="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/60"
 						placeholder="Search by name or email"
 						bind:value={query}
+						on:input={handleSearchInput}
 						data-testid="admin-search"
 					/>
 				</div>
 				<div class="mt-5 space-y-2">
 					{#if loading && players.length === 0}
 						<div class="text-sm text-slate-200/70">Loading roster...</div>
-					{:else if filteredPlayers.length === 0}
+					{:else if players.length === 0}
 						<div class="text-sm text-slate-200/70">No players match this search.</div>
 					{:else}
-						{#each filteredPlayers as player (player.id)}
+						{#each players as player (player.id)}
 							<button
 								class={`flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left text-sm transition ${
 									selectedPlayer?.id === player.id
@@ -493,6 +505,29 @@
 						{/each}
 					{/if}
 				</div>
+				{#if totalPages > 1}
+					<div class="mt-4 flex items-center justify-between border-t border-white/10 pt-4">
+						<button
+							class="rounded-xl border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+							on:click={() => goToPage(page - 1)}
+							disabled={page <= 1 || loading}
+							data-testid="admin-prev-page"
+						>
+							Previous
+						</button>
+						<span class="text-xs text-slate-200/60" data-testid="admin-page-indicator">
+							Page {page} of {totalPages}
+						</span>
+						<button
+							class="rounded-xl border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+							on:click={() => goToPage(page + 1)}
+							disabled={page >= totalPages || loading}
+							data-testid="admin-next-page"
+						>
+							Next
+						</button>
+					</div>
+				{/if}
 			</div>
 
 			<div class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl">

--- a/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
@@ -87,7 +87,9 @@
 	let passwordValidationError = $derived(getAdminPasswordValidationError(passwordDraft));
 
 	function handleSearchInput() {
-		if (searchTimeout) clearTimeout(searchTimeout);
+		if (searchTimeout) {
+			clearTimeout(searchTimeout);
+		}
 		searchTimeout = setTimeout(() => {
 			page = 1;
 			void loadPlayers();
@@ -95,7 +97,9 @@
 	}
 
 	function goToPage(newPage: number) {
-		if (newPage < 1 || newPage > totalPages || loading) return;
+		if (newPage < 1 || newPage > totalPages || loading) {
+			return;
+		}
 		page = newPage;
 		void loadPlayers();
 	}

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/admin-pagination.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/admin-pagination.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+test('admin roster sends search and pagination query parameters', async ({ page }) => {
+	const requests: Array<{ search: string | null; page: string | null; pageSize: string | null }> =
+		[];
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Admin',
+				email: 'admin@example.com',
+				createdOn: '2025-01-01T00:00:00Z',
+				isAdmin: true
+			})
+		});
+	});
+
+	await page.route('**/api/Admin/players**', async (route) => {
+		const url = new URL(route.request().url());
+		requests.push({
+			search: url.searchParams.get('search'),
+			page: url.searchParams.get('page'),
+			pageSize: url.searchParams.get('pageSize')
+		});
+
+		const requestedPage = Number(url.searchParams.get('page') ?? '1');
+		const search = url.searchParams.get('search');
+		const player =
+			search === 'beta'
+				? {
+						id: '22222222-2222-2222-2222-222222222222',
+						displayName: 'Beta Player',
+						email: 'beta@example.com',
+						createdOn: '2025-01-03T00:00:00Z',
+						isAdmin: false,
+						attemptCount: 1
+					}
+				: {
+						id:
+							requestedPage === 2
+								? '33333333-3333-3333-3333-333333333333'
+								: '11111111-1111-1111-1111-111111111111',
+						displayName: requestedPage === 2 ? 'Second Page' : 'First Page',
+						email: requestedPage === 2 ? 'second@example.com' : 'first@example.com',
+						createdOn: '2025-01-02T00:00:00Z',
+						isAdmin: false,
+						attemptCount: requestedPage
+					};
+
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				players: [player],
+				totalCount: search === 'beta' ? 1 : 21,
+				page: requestedPage,
+				pageSize: 20
+			})
+		});
+	});
+
+	await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.locator('[data-testid="admin-page"]')).toBeVisible();
+	await expect(page.getByText('First Page')).toBeVisible();
+	await expect(page.locator('[data-testid="admin-page-indicator"]')).toContainText('Page 1 of 2');
+
+	await page.locator('[data-testid="admin-next-page"]').click();
+	await expect(page.getByText('Second Page')).toBeVisible();
+
+	await page.locator('[data-testid="admin-search"]').fill('beta');
+	await expect(page.getByText('Beta Player')).toBeVisible();
+
+	expect(requests).toContainEqual({ search: null, page: '1', pageSize: '20' });
+	expect(requests).toContainEqual({ search: null, page: '2', pageSize: '20' });
+	expect(requests).toContainEqual({ search: 'beta', page: '1', pageSize: '20' });
+});


### PR DESCRIPTION
## Summary

- Replaces the client-side filtered player list with server-side paginated search
- Adds `GetPlayersPage` through all layers: `IPlayerRepository` → `PlayerRepository` (EF Core offset pagination, case-insensitive `Contains`) → `IAdminService` → `AdminService` → `AdminController`
- New `AdminPlayersPageResponse` DTO returns `players`, `totalCount`, `page`, `pageSize`
- Frontend admin page now debounces search input (300ms), resets to page 1 on new search, and shows Prev/Next pagination controls with page indicator
- All three test fake repositories updated to implement `GetPlayersPage`; two new unit tests cover search filtering and multi-page pagination

## Test plan

- [x] 77 backend xUnit tests pass (`docker-compose --profile tests run --rm tests-backend`)
- [x] 37 frontend unit tests pass (`npm test`)
- [x] `npm run format && npm run lint` clean
- [x] Manual behavior covered by focused Playwright admin pagination/search test

Closes #33

🤖 Generated with Codex