### PR TITLE
Show current player on stats page (#98)

### DIFF
--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -17,7 +17,12 @@
 		type ConfettiPiece
 	} from '$lib/game/confetti';
 	import { getKeyboardLetterState } from '$lib/game/keyboard';
-	import type { GameStateResponse, GuessResponse, LetterResult, PlayerStatsResponse } from '$lib/game/types';
+	import type {
+		GameStateResponse,
+		GuessResponse,
+		LetterResult,
+		PlayerStatsResponse
+	} from '$lib/game/types';
 	import { onMount, tick } from 'svelte';
 
 	let checking = true;
@@ -278,7 +283,10 @@
 		return `animation-delay:${position * 220}ms`;
 	}
 
-	function keyState(letter: string, guesses: GuessResponse[] | null | undefined): LetterResult | null {
+	function keyState(
+		letter: string,
+		guesses: GuessResponse[] | null | undefined
+	): LetterResult | null {
 		return getKeyboardLetterState(guesses, letter);
 	}
 
@@ -510,7 +518,9 @@
 											onclick={() => pushLetter(letter)}
 											disabled={guessInputLocked}
 											data-testid={`keyboard-key-${letter}`}
-											data-state={(keyState(letter, state?.attempt?.guesses) ?? 'unused').toLowerCase()}
+											data-state={(
+												keyState(letter, state?.attempt?.guesses) ?? 'unused'
+											).toLowerCase()}
 										>
 											{letter}
 										</button>

--- a/src/Wordle.TrackerSupreme.Web/src/routes/stats/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/stats/+page.svelte
@@ -39,7 +39,7 @@
 		try {
 			const request = buildStatsFilterRequest(filters);
 			const data = await StatsService.postApiStatsPlayers({ requestBody: request });
-			entries = data.filter((entry) => entry.playerId !== $auth.user?.id);
+			entries = data;
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Unable to load player stats.';
 		} finally {

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/stats.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/stats.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('stats page defaults to hard mode filters and excludes current player', async ({ page }) => {
+test('stats page defaults to hard mode filters and includes current player', async ({ page }) => {
 	page.on('pageerror', (error) => {
 		console.error('pageerror', error);
 	});
@@ -66,7 +66,7 @@ test('stats page defaults to hard mode filters and excludes current player', asy
 
 	await expect(page.getByRole('heading', { name: 'Every player, every lens' })).toBeVisible();
 	await expect(page.locator('main').getByText('Rival', { exact: true })).toBeVisible();
-	await expect(page.locator('main').getByText('Tester', { exact: true })).toHaveCount(0);
+	await expect(page.locator('main').getByText('Tester', { exact: true })).toBeVisible();
 
 	await expect(page.getByLabel('Easy mode attempts')).toBeVisible();
 	await page.getByLabel('Easy mode attempts').check();


### PR DESCRIPTION
## Summary
- keep the authenticated player in the stats page results instead of filtering them out client-side
- update the stats UI regression to require the signed-in player card to render
- apply a small Prettier cleanup needed for the existing frontend lint command

## Verification
- `npx playwright test --config playwright.config.ts tests/ui/stats.spec.ts` (red before fix, then passed)
- `npm run test -- --run` (37 passed)
- `npm run lint` (passed)
- `git diff --check` (passed)
- `./scripts/e2e.sh` blocked locally: Docker Compose v2 is unavailable (`docker compose` is not installed; only `docker-compose 1.29.2` is present), so `docker compose --profile` exits with `unknown flag: --profile`.

Closes #98

🤖 Generated with Codex