### PR TITLE
Add puzzle stream data model (#101)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/DailyPuzzleService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/DailyPuzzleService.cs
@@ -27,9 +27,12 @@ public class DailyPuzzleService : IDailyPuzzleService
         _logger = logger;
     }
 
-    public async Task<DailyPuzzle> GetOrCreatePuzzle(DateOnly puzzleDate, CancellationToken cancellationToken)
+    public async Task<DailyPuzzle> GetOrCreatePuzzle(
+        DateOnly puzzleDate,
+        PuzzleStream stream,
+        CancellationToken cancellationToken)
     {
-        var existing = await _gameRepository.GetPuzzleByDate(puzzleDate, cancellationToken);
+        var existing = await _gameRepository.GetPuzzleByDate(puzzleDate, stream, cancellationToken);
         if (existing is not null)
         {
             if (string.IsNullOrWhiteSpace(existing.Solution))
@@ -45,6 +48,7 @@ public class DailyPuzzleService : IDailyPuzzleService
         {
             Id = Guid.NewGuid(),
             PuzzleDate = puzzleDate,
+            Stream = stream,
             Solution = await ResolveSolution(puzzleDate, cancellationToken),
             IsArchived = false
         };

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/GameplayService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/GameplayService.cs
@@ -17,7 +17,7 @@ public class GameplayService(
 
     public async Task<GameplayState> GetState(Guid playerId, CancellationToken cancellationToken = default)
     {
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, cancellationToken);
+        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
 
         var cutoffPassed = gameClock.HasRevealPassed(puzzle.PuzzleDate);
@@ -36,7 +36,7 @@ public class GameplayService(
     public async Task<GameplayState> SubmitGuess(Guid playerId, string guessWord, CancellationToken cancellationToken = default)
     {
         var normalizedGuess = _guessEvaluationService.NormalizeGuess(guessWord);
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, cancellationToken);
+        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
 
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
         if (attempt is null)
@@ -122,7 +122,7 @@ public class GameplayService(
 
     public async Task<GameplayState> EnableEasyMode(Guid playerId, CancellationToken cancellationToken = default)
     {
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, cancellationToken);
+        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
 
         if (attempt is null)
@@ -164,7 +164,7 @@ public class GameplayService(
 
     public async Task<SolutionsSnapshot> GetSolutions(CancellationToken cancellationToken = default)
     {
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, cancellationToken);
+        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
         var cutoffPassed = gameClock.HasRevealPassed(puzzle.PuzzleDate);
 
         var attempts = await gameRepository.GetAttemptsForPuzzle(puzzle.Id, cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/DailyPuzzle.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/DailyPuzzle.cs
@@ -4,6 +4,7 @@ public class DailyPuzzle
 {
     public Guid Id { get; set; }
     public DateOnly PuzzleDate { get; set; }
+    public PuzzleStream Stream { get; set; } = PuzzleStream.NewYorkTimes;
     public string? Solution { get; set; }
     public bool IsArchived { get; set; }
     public ICollection<PlayerPuzzleAttempt> Attempts { get; set; } = [];

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/PuzzleStream.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Models/PuzzleStream.cs
@@ -1,0 +1,7 @@
+namespace Wordle.TrackerSupreme.Domain.Models;
+
+public enum PuzzleStream
+{
+    TrackerSupreme = 0,
+    NewYorkTimes = 1
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IGameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Repositories/IGameRepository.cs
@@ -4,7 +4,7 @@ namespace Wordle.TrackerSupreme.Domain.Repositories;
 
 public interface IGameRepository
 {
-    Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, CancellationToken cancellationToken);
+    Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, PuzzleStream stream, CancellationToken cancellationToken);
     Task AddPuzzle(DailyPuzzle puzzle, CancellationToken cancellationToken);
     Task<PlayerPuzzleAttempt?> GetAttempt(Guid playerId, Guid puzzleId, CancellationToken cancellationToken);
     Task<PlayerPuzzleAttempt?> GetAttemptWithDetails(Guid attemptId, CancellationToken cancellationToken);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/IDailyPuzzleService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/IDailyPuzzleService.cs
@@ -4,5 +4,5 @@ namespace Wordle.TrackerSupreme.Domain.Services.Game;
 
 public interface IDailyPuzzleService
 {
-    Task<DailyPuzzle> GetOrCreatePuzzle(DateOnly puzzleDate, CancellationToken cancellationToken);
+    Task<DailyPuzzle> GetOrCreatePuzzle(DateOnly puzzleDate, PuzzleStream stream, CancellationToken cancellationToken);
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Database/EntityConfigurations/DailyPuzzleConfiguration.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Database/EntityConfigurations/DailyPuzzleConfiguration.cs
@@ -13,10 +13,13 @@ public class DailyPuzzleConfiguration : IEntityTypeConfiguration<DailyPuzzle>
         builder.Property(puzzle => puzzle.PuzzleDate)
             .IsRequired();
 
+        builder.Property(puzzle => puzzle.Stream)
+            .IsRequired();
+
         builder.Property(puzzle => puzzle.Solution)
             .HasMaxLength(5);
 
-        builder.HasIndex(puzzle => puzzle.PuzzleDate)
+        builder.HasIndex(puzzle => new { puzzle.PuzzleDate, puzzle.Stream })
             .IsUnique();
 
         builder.HasMany(puzzle => puzzle.Attempts)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Infrastructure/Repositories/GameRepository.cs
@@ -8,8 +8,10 @@ namespace Wordle.TrackerSupreme.Infrastructure.Repositories;
 
 public class GameRepository(WordleTrackerSupremeDbContext dbContext) : IGameRepository
 {
-    public Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, CancellationToken cancellationToken)
-        => dbContext.DailyPuzzles.FirstOrDefaultAsync(p => p.PuzzleDate == puzzleDate, cancellationToken);
+    public Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, PuzzleStream stream, CancellationToken cancellationToken)
+        => dbContext.DailyPuzzles.FirstOrDefaultAsync(
+            p => p.PuzzleDate == puzzleDate && p.Stream == stream,
+            cancellationToken);
 
     public Task AddPuzzle(DailyPuzzle puzzle, CancellationToken cancellationToken)
     {

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Migrations/Migrations/20260421145328_AddPuzzleStream.Designer.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Migrations/Migrations/20260421145328_AddPuzzleStream.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Wordle.TrackerSupreme.Infrastructure.Database;
@@ -11,9 +12,11 @@ using Wordle.TrackerSupreme.Infrastructure.Database;
 namespace Wordle.TrackerSupreme.Migrations.Migrations
 {
     [DbContext(typeof(WordleTrackerSupremeDbContext))]
-    partial class WordleTrackerSupremeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421145328_AddPuzzleStream")]
+    partial class AddPuzzleStream
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Migrations/Migrations/20260421145328_AddPuzzleStream.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Migrations/Migrations/20260421145328_AddPuzzleStream.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wordle.TrackerSupreme.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPuzzleStream : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Stream",
+                table: "DailyPuzzles",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.Sql("""
+                UPDATE "DailyPuzzles"
+                SET "Stream" = 1
+                WHERE "Stream" IS NULL;
+                """);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Stream",
+                table: "DailyPuzzles",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.DropIndex(
+                name: "IX_DailyPuzzles_PuzzleDate",
+                table: "DailyPuzzles");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyPuzzles_PuzzleDate_Stream",
+                table: "DailyPuzzles",
+                columns: new[] { "PuzzleDate", "Stream" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DailyPuzzles_PuzzleDate_Stream",
+                table: "DailyPuzzles");
+
+            migrationBuilder.DropColumn(
+                name: "Stream",
+                table: "DailyPuzzles");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyPuzzles_PuzzleDate",
+                table: "DailyPuzzles",
+                column: "PuzzleDate",
+                unique: true);
+        }
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/DailyPuzzleServiceTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/DailyPuzzleServiceTests.cs
@@ -20,9 +20,10 @@ public class DailyPuzzleServiceTests
         var officialProvider = new FakeOfficialWordProvider("RANGE");
         var service = CreateService(repo, officialProvider);
 
-        var puzzle = await service.GetOrCreatePuzzle(new DateOnly(2025, 1, 1), CancellationToken.None);
+        var puzzle = await service.GetOrCreatePuzzle(new DateOnly(2025, 1, 1), PuzzleStream.NewYorkTimes, CancellationToken.None);
 
         puzzle.Solution.Should().Be("RANGE");
+        puzzle.Stream.Should().Be(PuzzleStream.NewYorkTimes);
         officialProvider.CallCount.Should().Be(1);
     }
 
@@ -40,7 +41,7 @@ public class DailyPuzzleServiceTests
         await repo.AddPuzzle(existing, CancellationToken.None);
         var service = CreateService(repo, officialProvider);
 
-        var puzzle = await service.GetOrCreatePuzzle(existing.PuzzleDate, CancellationToken.None);
+        var puzzle = await service.GetOrCreatePuzzle(existing.PuzzleDate, PuzzleStream.NewYorkTimes, CancellationToken.None);
 
         puzzle.Id.Should().Be(existing.Id);
         puzzle.Solution.Should().Be("PLANT");
@@ -54,7 +55,10 @@ public class DailyPuzzleServiceTests
         var officialProvider = new FakeOfficialWordProvider((_, _) => throw new InvalidOperationException("boom"));
         var service = CreateService(repo, officialProvider);
 
-        var act = async () => await service.GetOrCreatePuzzle(new DateOnly(2025, 1, 3), CancellationToken.None);
+        var act = async () => await service.GetOrCreatePuzzle(
+            new DateOnly(2025, 1, 3),
+            PuzzleStream.NewYorkTimes,
+            CancellationToken.None);
 
         await act.Should().ThrowAsync<DailyPuzzleUnavailableException>()
             .WithMessage("Unable to retrieve today's puzzle. Please try again later.");

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeGameRepository.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/Fakes/FakeGameRepository.cs
@@ -59,9 +59,9 @@ public class FakeGameRepository : IGameRepository
         return Task.FromResult(attempts);
     }
 
-    public Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, CancellationToken cancellationToken)
+    public Task<DailyPuzzle?> GetPuzzleByDate(DateOnly puzzleDate, PuzzleStream stream, CancellationToken cancellationToken)
     {
-        var puzzle = _puzzles.FirstOrDefault(p => p.PuzzleDate == puzzleDate);
+        var puzzle = _puzzles.FirstOrDefault(p => p.PuzzleDate == puzzleDate && p.Stream == stream);
         return Task.FromResult<DailyPuzzle?>(puzzle);
     }
 

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameRepositoryTests.cs
@@ -12,6 +12,138 @@ namespace Wordle.TrackerSupreme.Tests;
 public class GameRepositoryTests
 {
     [Fact]
+    public void DailyPuzzle_model_uses_date_and_stream_unique_index()
+    {
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+
+        using var dbContext = new WordleTrackerSupremeDbContext(options);
+        var entityType = dbContext.Model.FindEntityType(typeof(DailyPuzzle));
+
+        var index = entityType!.GetIndexes()
+            .Single(i => i.Properties
+                .Select(p => p.Name)
+                .SequenceEqual([nameof(DailyPuzzle.PuzzleDate), nameof(DailyPuzzle.Stream)]));
+
+        index.IsUnique.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DailyPuzzles_allows_same_date_when_stream_differs()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await CreateDailyPuzzlesTable(options);
+
+        var puzzleDate = new DateOnly(2026, 4, 21);
+
+        await using var dbContext = new WordleTrackerSupremeDbContext(options);
+        dbContext.DailyPuzzles.AddRange(
+            new DailyPuzzle
+            {
+                Id = Guid.NewGuid(),
+                PuzzleDate = puzzleDate,
+                Stream = PuzzleStream.TrackerSupreme,
+                Solution = "CRANE"
+            },
+            new DailyPuzzle
+            {
+                Id = Guid.NewGuid(),
+                PuzzleDate = puzzleDate,
+                Stream = PuzzleStream.NewYorkTimes,
+                Solution = "SLATE"
+            });
+
+        await dbContext.SaveChangesAsync();
+
+        dbContext.DailyPuzzles.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DailyPuzzles_rejects_same_date_and_stream_duplicate()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await CreateDailyPuzzlesTable(options);
+
+        var puzzleDate = new DateOnly(2026, 4, 21);
+
+        await using var dbContext = new WordleTrackerSupremeDbContext(options);
+        dbContext.DailyPuzzles.AddRange(
+            new DailyPuzzle
+            {
+                Id = Guid.NewGuid(),
+                PuzzleDate = puzzleDate,
+                Stream = PuzzleStream.NewYorkTimes,
+                Solution = "CRANE"
+            },
+            new DailyPuzzle
+            {
+                Id = Guid.NewGuid(),
+                PuzzleDate = puzzleDate,
+                Stream = PuzzleStream.NewYorkTimes,
+                Solution = "SLATE"
+            });
+
+        var act = async () => await dbContext.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task GetPuzzleByDate_returns_requested_stream()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<WordleTrackerSupremeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await CreateDailyPuzzlesTable(options);
+
+        var puzzleDate = new DateOnly(2026, 4, 21);
+        await using (var seedContext = new WordleTrackerSupremeDbContext(options))
+        {
+            seedContext.DailyPuzzles.AddRange(
+                new DailyPuzzle
+                {
+                    Id = Guid.NewGuid(),
+                    PuzzleDate = puzzleDate,
+                    Stream = PuzzleStream.TrackerSupreme,
+                    Solution = "CRANE"
+                },
+                new DailyPuzzle
+                {
+                    Id = Guid.NewGuid(),
+                    PuzzleDate = puzzleDate,
+                    Stream = PuzzleStream.NewYorkTimes,
+                    Solution = "SLATE"
+                });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using var dbContext = new WordleTrackerSupremeDbContext(options);
+        var repository = new GameRepository(dbContext);
+
+        var puzzle = await repository.GetPuzzleByDate(puzzleDate, PuzzleStream.NewYorkTimes, CancellationToken.None);
+
+        puzzle.Should().NotBeNull();
+        puzzle!.Solution.Should().Be("SLATE");
+    }
+
+    [Fact]
     public async Task SaveChanges_translates_duplicate_attempt_unique_index_violation()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");
@@ -70,6 +202,24 @@ public class GameRepositoryTests
 
         await act.Should().ThrowAsync<DuplicatePuzzleAttemptException>()
             .WithMessage("You already have an attempt for today's puzzle. Refresh to continue.");
+    }
+
+    private static async Task CreateDailyPuzzlesTable(DbContextOptions<WordleTrackerSupremeDbContext> options)
+    {
+        await using var setupContext = new WordleTrackerSupremeDbContext(options);
+        await setupContext.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TABLE DailyPuzzles (
+                Id TEXT NOT NULL PRIMARY KEY,
+                PuzzleDate TEXT NOT NULL,
+                Stream INTEGER NOT NULL,
+                Solution TEXT NULL,
+                IsArchived INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE UNIQUE INDEX IX_DailyPuzzles_PuzzleDate_Stream
+                ON DailyPuzzles (PuzzleDate, Stream);
+            """);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add a `PuzzleStream` domain enum and persist stream identity on `DailyPuzzle`
- replace date-only puzzle uniqueness with `(PuzzleDate, Stream)` uniqueness so Tracker Supreme and NYT puzzles can coexist on the same date
- add a migration that backfills existing daily puzzles as `NewYorkTimes` before enforcing the stream column
- make repository and daily puzzle service lookups stream-aware while preserving current gameplay on the NYT stream until the gameplay follow-up lands

## Verification
- `docker-compose --profile tests run --rm tests-backend -lc 'dotnet test Wordle.TrackerSupreme.Tests/Wordle.TrackerSupreme.Tests.csproj --filter FullyQualifiedName~GameRepositoryTests'` (red before implementation, then passed: 6 passed)
- `docker-compose --profile tests run --rm tests-backend` (passed: 79 passed; existing NU1903 warnings for `System.Security.Cryptography.Xml` 9.0.0)
- `git diff --check`

## API / Data Contract Impact
- [x] No API contract changes
- [ ] `openapi.json` updated
- [ ] frontend API client regenerated
- [x] migration added

## Notes
- Current gameplay endpoints still use the NYT stream. The default Tracker Supreme gameplay switch belongs to #102.
- This PR depends conceptually on the migration/backfill plan in #107, but includes the concrete migration required for #101.

Closes #101

🤖 Generated with Codex