### PR TITLE
Update admin and seeding workflows for puzzle streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ This project uses Docker Compose to run:
    - `Seeder__DefaultPassword=dev-password`
    - `Seeder__AllowReseed=false`
    - `Seeder__AnchorDate=2025-02-01`
+   `Seeder__PuzzleDays` is the number of dates to seed per puzzle stream. Each seeded date gets both a
+   Tracker Supreme puzzle and a New York Times puzzle so admin and leaderboard screens can show same-date
+   stream-specific data.
 5) Stop everything:
    ```bash
    docker compose down

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/AdminController.cs
@@ -194,6 +194,7 @@ public class AdminController(IAdminService adminService) : ControllerBase
         return new AdminPlayerAttemptResponse(
             attempt.Id,
             attempt.DailyPuzzle.PuzzleDate,
+            attempt.DailyPuzzle.Stream,
             attempt.Status,
             attempt.PlayedInHardMode,
             attempt.CreatedOn,

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminPlayerDetailResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Admin/AdminPlayerDetailResponse.cs
@@ -14,6 +14,7 @@ public record AdminPlayerDetailResponse(
 public record AdminPlayerAttemptResponse(
     Guid AttemptId,
     DateOnly PuzzleDate,
+    PuzzleStream Stream,
     AttemptStatus Status,
     bool PlayedInHardMode,
     DateTime CreatedOn,

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Seeder/SeedDataGenerator.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Seeder/SeedDataGenerator.cs
@@ -38,7 +38,7 @@ public class SeedDataGenerator(
         var random = new Random(_options.RandomSeed);
         var players = BuildPlayers(random, anchorDate);
         var puzzles = BuildPuzzles(anchorDate, random);
-        var attempts = BuildAttempts(random, anchorDate, players, puzzles);
+        var attempts = BuildAttempts(random, players, puzzles);
         EnsureFeaturedAttempts(attempts, players, puzzles);
 
         return new SeedData(players, puzzles, attempts);
@@ -103,66 +103,97 @@ public class SeedDataGenerator(
     {
         var requiredDays = _options.MaxSolvedPuzzles + _options.FailedPuzzlesMax + _options.InProgressPuzzlesMax;
         var totalDays = Math.Max(_options.PuzzleDays, requiredDays);
-        var puzzles = new List<DailyPuzzle>(totalDays);
+        var streams = Enum.GetValues<PuzzleStream>();
+        var puzzles = new List<DailyPuzzle>(totalDays * streams.Length);
 
-        for (int i = 0; i < totalDays; i++)
+        for (int i = totalDays - 1; i >= 0; i--)
         {
             var date = anchorDate.AddDays(-i);
-            puzzles.Add(new DailyPuzzle
+            foreach (var stream in streams)
             {
-                Id = Guid.NewGuid(),
-                PuzzleDate = date,
-                Stream = PuzzleStream.TrackerSupreme,
-                Solution = _wordSelector.GetSolutionFor(date),
-                IsArchived = date < anchorDate
-            });
+                puzzles.Add(new DailyPuzzle
+                {
+                    Id = Guid.NewGuid(),
+                    PuzzleDate = date,
+                    Stream = stream,
+                    Solution = GetSeedSolution(date, stream),
+                    IsArchived = date < anchorDate
+                });
+            }
         }
 
-        puzzles.Reverse();
         return puzzles;
+    }
+
+    private string GetSeedSolution(DateOnly date, PuzzleStream stream)
+    {
+        if (stream == PuzzleStream.TrackerSupreme)
+        {
+            return _wordSelector.GetSolutionFor(date);
+        }
+
+        return _wordSelector.GetSolutionFor(date.AddDays(17));
     }
 
     private List<PlayerPuzzleAttempt> BuildAttempts(
         Random random,
-        DateOnly anchorDate,
         IReadOnlyList<Player> players,
         IReadOnlyList<DailyPuzzle> puzzles)
     {
         var attempts = new List<PlayerPuzzleAttempt>();
-        var totalDays = puzzles.Count;
         var maxGuesses = _gameOptions.MaxGuesses;
+        var puzzlesByStream = puzzles
+            .GroupBy(puzzle => puzzle.Stream)
+            .OrderBy(group => group.Key)
+            .ToList();
 
         foreach (var player in players)
         {
-            var solvedCount = random.Next(_options.MinSolvedPuzzles, _options.MaxSolvedPuzzles + 1);
-            var failedCount = random.Next(_options.FailedPuzzlesMin, _options.FailedPuzzlesMax + 1);
-            var inProgressCount = random.Next(_options.InProgressPuzzlesMin, _options.InProgressPuzzlesMax + 1);
-            var totalCount = Math.Min(totalDays, solvedCount + failedCount + inProgressCount);
-
-            var puzzleOrder = puzzles
-                .OrderBy(_ => random.Next())
-                .Take(totalCount)
-                .ToList();
-
-            var solved = puzzleOrder.Take(Math.Min(solvedCount, puzzleOrder.Count)).ToList();
-            var remaining = puzzleOrder.Skip(solved.Count).ToList();
-            var failed = remaining.Take(Math.Min(failedCount, remaining.Count)).ToList();
-            var inProgress = remaining.Skip(failed.Count).Take(Math.Min(inProgressCount, remaining.Count - failed.Count)).ToList();
-
-            foreach (var puzzle in solved)
+            foreach (var streamPuzzles in puzzlesByStream)
             {
-                attempts.Add(BuildSolvedAttempt(player, puzzle, random, maxGuesses));
+                attempts.AddRange(BuildAttemptsForStream(random, player, streamPuzzles.ToList(), maxGuesses));
             }
+        }
 
-            foreach (var puzzle in failed)
-            {
-                attempts.Add(BuildFailedAttempt(player, puzzle, random, maxGuesses));
-            }
+        return attempts;
+    }
 
-            foreach (var puzzle in inProgress)
-            {
-                attempts.Add(BuildInProgressAttempt(player, puzzle, random, maxGuesses));
-            }
+    private List<PlayerPuzzleAttempt> BuildAttemptsForStream(
+        Random random,
+        Player player,
+        IReadOnlyList<DailyPuzzle> puzzles,
+        int maxGuesses)
+    {
+        var attempts = new List<PlayerPuzzleAttempt>();
+        var totalDays = puzzles.Count;
+        var solvedCount = random.Next(_options.MinSolvedPuzzles, _options.MaxSolvedPuzzles + 1);
+        var failedCount = random.Next(_options.FailedPuzzlesMin, _options.FailedPuzzlesMax + 1);
+        var inProgressCount = random.Next(_options.InProgressPuzzlesMin, _options.InProgressPuzzlesMax + 1);
+        var totalCount = Math.Min(totalDays, solvedCount + failedCount + inProgressCount);
+
+        var puzzleOrder = puzzles
+            .OrderBy(_ => random.Next())
+            .Take(totalCount)
+            .ToList();
+
+        var solved = puzzleOrder.Take(Math.Min(solvedCount, puzzleOrder.Count)).ToList();
+        var remaining = puzzleOrder.Skip(solved.Count).ToList();
+        var failed = remaining.Take(Math.Min(failedCount, remaining.Count)).ToList();
+        var inProgress = remaining.Skip(failed.Count).Take(Math.Min(inProgressCount, remaining.Count - failed.Count)).ToList();
+
+        foreach (var puzzle in solved)
+        {
+            attempts.Add(BuildSolvedAttempt(player, puzzle, random, maxGuesses));
+        }
+
+        foreach (var puzzle in failed)
+        {
+            attempts.Add(BuildFailedAttempt(player, puzzle, random, maxGuesses));
+        }
+
+        foreach (var puzzle in inProgress)
+        {
+            attempts.Add(BuildInProgressAttempt(player, puzzle, random, maxGuesses));
         }
 
         return attempts;

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/AdminControllerTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Wordle.TrackerSupreme.Api.Controllers;
+using Wordle.TrackerSupreme.Api.Models.Admin;
+using Wordle.TrackerSupreme.Domain.Models;
+using Wordle.TrackerSupreme.Domain.Services;
+using Xunit;
+
+namespace Wordle.TrackerSupreme.Tests;
+
+public class AdminControllerTests
+{
+    [Fact]
+    public async Task GetPlayer_includes_attempt_stream()
+    {
+        var player = new Player
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Stream Admin",
+            Email = "stream@example.com",
+            PasswordHash = "hash",
+            Attempts =
+            [
+                new PlayerPuzzleAttempt
+                {
+                    Id = Guid.NewGuid(),
+                    PlayerId = Guid.NewGuid(),
+                    DailyPuzzle = new DailyPuzzle
+                    {
+                        Id = Guid.NewGuid(),
+                        PuzzleDate = new DateOnly(2025, 2, 1),
+                        Stream = PuzzleStream.NewYorkTimes,
+                        Solution = "CRANE"
+                    },
+                    Status = AttemptStatus.Solved,
+                    PlayedInHardMode = true,
+                    CreatedOn = DateTime.UtcNow,
+                    CompletedOn = DateTime.UtcNow,
+                    Guesses = []
+                }
+            ]
+        };
+        var controller = new AdminController(new FakeAdminService(player));
+
+        var result = await controller.GetPlayer(player.Id, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = ok.Value.Should().BeOfType<AdminPlayerDetailResponse>().Subject;
+        response.Attempts.Should().ContainSingle();
+        response.Attempts.Single().Stream.Should().Be(PuzzleStream.NewYorkTimes);
+    }
+
+    private sealed class FakeAdminService(Player player) : IAdminService
+    {
+        public Task<IReadOnlyList<Player>> GetPlayers(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<Player>>([player]);
+        }
+
+        public Task<Player?> GetPlayer(Guid playerId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<Player?>(player.Id == playerId ? player : null);
+        }
+
+        public Task<Player> UpdatePlayerProfile(
+            Guid playerId,
+            string displayName,
+            string email,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<Player> ResetPassword(Guid playerId, string newPassword, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<Player> SetAdminStatus(Guid playerId, bool isAdmin, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<PlayerPuzzleAttempt> UpdateAttempt(
+            Guid attemptId,
+            IReadOnlyList<string> guesses,
+            bool playedInHardMode,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task DeleteAttempt(Guid attemptId, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeedDataGeneratorTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeedDataGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace Wordle.TrackerSupreme.Tests;
 public class SeedDataGeneratorTests
 {
     [Fact]
-    public void Generate_assigns_tracker_supreme_stream_to_seeded_puzzles()
+    public void Generate_creates_representative_puzzles_and_attempts_for_each_stream()
     {
         var generator = new SeedDataGenerator(
             new SeederOptions
@@ -35,7 +35,15 @@ public class SeedDataGeneratorTests
         var data = generator.Generate(new DateOnly(2025, 2, 1));
 
         data.Puzzles.Should().NotBeEmpty();
-        data.Puzzles.Should().OnlyContain(puzzle => puzzle.Stream == PuzzleStream.TrackerSupreme);
+        data.Puzzles.Select(puzzle => puzzle.Stream).Should().Contain(PuzzleStream.TrackerSupreme);
+        data.Puzzles.Select(puzzle => puzzle.Stream).Should().Contain(PuzzleStream.NewYorkTimes);
+        data.Puzzles
+            .GroupBy(puzzle => puzzle.PuzzleDate)
+            .Should()
+            .OnlyContain(group => group.Select(puzzle => puzzle.Stream).ToHashSet()
+                .SetEquals(new[] { PuzzleStream.TrackerSupreme, PuzzleStream.NewYorkTimes }));
+        data.Attempts.Select(attempt => attempt.DailyPuzzle.Stream).Should().Contain(PuzzleStream.TrackerSupreme);
+        data.Attempts.Select(attempt => attempt.DailyPuzzle.Stream).Should().Contain(PuzzleStream.NewYorkTimes);
     }
 
     private sealed class TestWordListProvider : IWordListProvider

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeederRunnerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/SeederRunnerTests.cs
@@ -49,9 +49,9 @@ public class SeederRunnerTests
 
         var totalPlayers = options.PlayerCount + 1;
         dbContext.Players.Should().HaveCount(totalPlayers);
-        dbContext.DailyPuzzles.Should().HaveCount(options.PuzzleDays);
+        dbContext.DailyPuzzles.Should().HaveCount(options.PuzzleDays * 2);
         var featuredCount = Math.Min(4, totalPlayers);
-        dbContext.Attempts.Should().HaveCount(totalPlayers * 5 + featuredCount);
+        dbContext.Attempts.Should().HaveCount(totalPlayers * 10 + featuredCount);
 
         var attempts = await dbContext.Attempts
             .Include(a => a.DailyPuzzle)
@@ -79,7 +79,7 @@ public class SeederRunnerTests
         await runner.SeedAsync();
 
         dbContext.Players.Should().HaveCount(totalPlayers);
-        dbContext.Attempts.Should().HaveCount(totalPlayers * 5 + featuredCount);
+        dbContext.Attempts.Should().HaveCount(totalPlayers * 10 + featuredCount);
     }
 
     [Fact]
@@ -133,7 +133,8 @@ public class SeederRunnerTests
             options.PuzzleDays,
             options.MinSolvedPuzzles + options.FailedPuzzlesMin + options.InProgressPuzzlesMin);
         dbContext.Players.Count().Should().Be(totalPlayers);
-        dbContext.Attempts.Count().Should().Be(totalPlayers * expectedPerPlayer + featuredCount);
+        dbContext.DailyPuzzles.Count().Should().Be(options.PuzzleDays * 2);
+        dbContext.Attempts.Count().Should().Be(totalPlayers * expectedPerPlayer * 2 + featuredCount);
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -812,6 +812,9 @@
 						"type": "string",
 						"format": "date"
 					},
+					"stream": {
+						"$ref": "#/components/schemas/PuzzleStream"
+					},
 					"status": {
 						"type": "string"
 					},

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/AdminPlayerAttemptResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/AdminPlayerAttemptResponse.ts
@@ -3,9 +3,11 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { GuessResponse } from './GuessResponse';
+import type { PuzzleStream } from './PuzzleStream';
 export type AdminPlayerAttemptResponse = {
 	attemptId?: string;
 	puzzleDate?: string;
+	stream?: PuzzleStream;
 	status?: string;
 	playedInHardMode?: boolean;
 	createdOn?: string;

--- a/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/admin/+page.svelte
@@ -8,6 +8,7 @@
 	import type { AdminPlayerDetailResponse as ApiAdminPlayerDetailResponse } from '$lib/api-client/models/AdminPlayerDetailResponse';
 	import type { AdminPlayerSummaryResponse as ApiAdminPlayerSummaryResponse } from '$lib/api-client/models/AdminPlayerSummaryResponse';
 	import type { GuessResponse } from '$lib/api-client/models/GuessResponse';
+	import type { PuzzleStream } from '$lib/api-client/models/PuzzleStream';
 	import {
 		displayNameMaxLength,
 		displayNameMinLength,
@@ -29,6 +30,7 @@
 	type AdminPlayerAttempt = {
 		attemptId: string;
 		puzzleDate: string;
+		stream: PuzzleStream;
 		status: string;
 		playedInHardMode: boolean;
 		createdOn: string;
@@ -102,6 +104,10 @@
 			return value;
 		}
 		return date.toLocaleDateString();
+	}
+
+	function formatPuzzleStream(stream: PuzzleStream) {
+		return stream === 'NewYorkTimes' ? 'New York Times' : 'Tracker Supreme';
 	}
 
 	function getRequestErrorMessage(err: unknown, fallback: string) {
@@ -381,6 +387,7 @@
 		return {
 			attemptId,
 			puzzleDate: attempt.puzzleDate ?? '',
+			stream: attempt.stream ?? 'TrackerSupreme',
 			status: attempt.status ?? 'Unknown',
 			playedInHardMode: attempt.playedInHardMode ?? true,
 			createdOn: attempt.createdOn ?? '',
@@ -643,6 +650,9 @@
 												<div>
 													<div class="text-sm font-semibold text-white">
 														{attempt.puzzleDate}
+													</div>
+													<div class="text-xs text-emerald-200/80">
+														{formatPuzzleStream(attempt.stream)}
 													</div>
 													<div class="text-xs text-slate-200/60">
 														Status: {attempt.status} • {attempt.guesses.length} guesses

--- a/src/Wordle.TrackerSupreme.Web/tests/e2e/admin.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/e2e/admin.spec.ts
@@ -15,6 +15,8 @@ test('admin can manage player profiles and attempts', async ({ page }) => {
 
 	const attemptCards = page.getByTestId('admin-attempt-card');
 	await expect(attemptCards.first()).toBeVisible();
+	await expect(attemptCards.filter({ hasText: 'Tracker Supreme' }).first()).toBeVisible();
+	await expect(attemptCards.filter({ hasText: 'New York Times' }).first()).toBeVisible();
 
 	await page.getByTestId('admin-email').fill('invalid-email');
 	await expect(page.getByText('Email must be a valid email address.')).toBeVisible();

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/admin-streams.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/admin-streams.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+
+test('admin attempt cards identify puzzle streams', async ({ page }) => {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Admin',
+				email: 'admin@example.com',
+				createdOn: '2025-01-01T00:00:00Z',
+				isAdmin: true
+			})
+		});
+	});
+
+	await page.route('**/api/Admin/players', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify([
+				{
+					id: '22222222-2222-2222-2222-222222222222',
+					displayName: 'Stream Player',
+					email: 'stream@example.com',
+					createdOn: '2025-01-02T00:00:00Z',
+					isAdmin: false,
+					attemptCount: 2
+				}
+			])
+		});
+	});
+
+	await page.route('**/api/Admin/players/22222222-2222-2222-2222-222222222222', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '22222222-2222-2222-2222-222222222222',
+				displayName: 'Stream Player',
+				email: 'stream@example.com',
+				createdOn: '2025-01-02T00:00:00Z',
+				isAdmin: false,
+				attempts: [
+					{
+						attemptId: '33333333-3333-3333-3333-333333333333',
+						puzzleDate: '2025-02-01',
+						stream: 'TrackerSupreme',
+						status: 'Solved',
+						playedInHardMode: true,
+						createdOn: '2025-02-01T09:00:00Z',
+						completedOn: '2025-02-01T09:20:00Z',
+						guesses: []
+					},
+					{
+						attemptId: '44444444-4444-4444-4444-444444444444',
+						puzzleDate: '2025-02-01',
+						stream: 'NewYorkTimes',
+						status: 'Failed',
+						playedInHardMode: false,
+						createdOn: '2025-02-01T10:00:00Z',
+						completedOn: '2025-02-01T10:20:00Z',
+						guesses: []
+					}
+				]
+			})
+		});
+	});
+
+	await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Checking your session...').waitFor({ state: 'hidden' });
+	await page.getByRole('button', { name: /Stream Player/ }).click();
+
+	const attemptCards = page.getByTestId('admin-attempt-card');
+	await expect(attemptCards).toHaveCount(2);
+	await expect(attemptCards.first()).toContainText('Tracker Supreme');
+	await expect(attemptCards.nth(1)).toContainText('New York Times');
+});


### PR DESCRIPTION
## Summary
- expose puzzle stream on admin attempt responses and show stream labels on admin attempt cards
- seed both Tracker Supreme and New York Times puzzles for each configured date, with representative attempts in both streams
- update README seeding expectations and add backend, UI, and E2E coverage for stream-aware admin/seeding behavior

Closes #104

## Verification
- docker-compose --profile tests run --rm tests-backend
- docker-compose --profile tests run --rm tests-backend -lc 'dotnet test Wordle.TrackerSupreme.sln --filter "FullyQualifiedName~AdminControllerTests|FullyQualifiedName~SeedDataGeneratorTests|FullyQualifiedName~SeederRunnerTests"'
- npm test -- --run
- npx playwright test --config playwright.config.ts
- npm run lint
- git diff --check
- ./scripts/e2e.sh (blocked on this VM: Docker Compose v2 `docker compose --profile` is unavailable)
- v1-compatible E2E equivalent: migrated, seeded, then E2E_BASE_URL=http://localhost:3000 npm run e2e

Note: npm run check still reports pre-existing type issues in the stacked frontend stream changes.

🤖 Generated with Codex