### PR TITLE
fix: refresh puzzle screen at unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,6 @@ Reset safety:
 - `.github/workflows/e2e.yml` – GitHub Actions E2E workflow
 
 ## Notes
+- The puzzle screen auto-refreshes when the next daily puzzle unlocks, so leaving it open will advance to the next puzzle after midnight.
 - Postgres is only reachable on the internal Docker network; expose `5432` in an override if you need host access.
 - Traefik is off by default to avoid Docker socket issues on Windows; enable it with `--profile proxy` after adjusting the socket mount for your platform. For HTTPS/domain use with Traefik, uncomment the ACME lines in `docker-compose.yml` and set `TRAEFIK_ACME_EMAIL` in your env file.

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+page.svelte
@@ -47,6 +47,7 @@
 	let shakeTimer: ReturnType<typeof setTimeout> | null = null;
 	let countdownInterval: ReturnType<typeof setInterval> | null = null;
 	let countdown = '';
+	let countdownReloaded = false;
 	let announcement: string | null = null;
 	let announcementIsError = false;
 	const keyboardRows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
@@ -347,9 +348,14 @@
 		if (countdownInterval) {
 			return;
 		}
+		countdownReloaded = false;
 		countdown = computeCountdown();
 		countdownInterval = setInterval(() => {
 			countdown = computeCountdown();
+			if (countdown === '00:00:00' && !countdownReloaded) {
+				countdownReloaded = true;
+				void loadState();
+			}
 		}, 1000);
 	}
 
@@ -358,6 +364,7 @@
 			clearInterval(countdownInterval);
 			countdownInterval = null;
 		}
+		countdownReloaded = false;
 	}
 
 	function resetCelebration() {


### PR DESCRIPTION
## Summary\n- reload the puzzle state when the midnight countdown reaches zero so the daily screen advances to the next puzzle\n- document the auto-refresh behavior in the README\n\n## Verification\n-  (fails due existing unrelated Svelte type errors in )