### PR TITLE
Sortable leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,6 @@ Reset safety:
 - `.github/workflows/e2e.yml` – GitHub Actions E2E workflow
 
 ## Notes
+- The leaderboard's all-time view supports sorting by the table headers, which map to `sort` and `direction` query params on `/api/stats/leaderboard`.
 - Postgres is only reachable on the internal Docker network; expose `5432` in an override if you need host access.
 - Traefik is off by default to avoid Docker socket issues on Windows; enable it with `--profile proxy` after adjusting the socket mount for your platform. For HTTPS/domain use with Traefik, uncomment the ACME lines in `docker-compose.yml` and set `TRAEFIK_ACME_EMAIL` in your env file.

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
@@ -17,6 +17,13 @@ public class StatsController(
     IPlayerStatisticsService statisticsService,
     IGameClock gameClock) : ControllerBase
 {
+    private const string DefaultLeaderboardSort = "winRate";
+
+    private sealed record LeaderboardCandidate(
+        Domain.Models.Player Player,
+        PlayerStatistics Stats,
+        double? WinRate);
+
     [HttpGet("me")]
     public async Task<ActionResult<PlayerStatsResponse>> GetMine(CancellationToken cancellationToken)
     {
@@ -63,10 +70,16 @@ public class StatsController(
     public async Task<ActionResult<LeaderboardPageResponse>> GetLeaderboard(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10,
+        [FromQuery] string sort = DefaultLeaderboardSort,
+        [FromQuery] string direction = "desc",
         CancellationToken cancellationToken = default)
     {
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 100);
+        var normalizedSort = string.IsNullOrWhiteSpace(sort) ? DefaultLeaderboardSort : sort.Trim();
+        var normalizedDirection = string.Equals(direction, "asc", StringComparison.OrdinalIgnoreCase)
+            ? "asc"
+            : "desc";
 
         var filter = new PlayerStatsFilterRequest(
             IncludeHardMode: true,
@@ -85,18 +98,11 @@ public class StatsController(
                 var winRate = stats.TotalAttempts > 0
                     ? stats.Wins / (double)stats.TotalAttempts
                     : (double?)null;
-                return new
-                {
-                    Player = player,
-                    Stats = stats,
-                    WinRate = winRate
-                };
+                return new LeaderboardCandidate(player, stats, winRate);
             })
             .Where(entry => entry.Stats.TotalAttempts > 0)
-            .OrderByDescending(entry => entry.WinRate ?? 0)
-            .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
-            .ThenByDescending(entry => entry.Stats.Wins)
-            .ThenBy(entry => entry.Player.DisplayName)
+            .OrderBy(entry => 0)
+            .ApplyLeaderboardSort(normalizedSort, normalizedDirection)
             .ToList();
 
         var total = ranked.Count;
@@ -185,5 +191,74 @@ public class StatsController(
             stats.LongestStreak,
             stats.AverageGuessCount,
             stats.GuessDistribution);
+    }
+
+    private static IOrderedEnumerable<LeaderboardCandidate> ApplyLeaderboardSort(
+        this IOrderedEnumerable<LeaderboardCandidate> entries,
+        string sort,
+        string direction)
+    {
+        var descending = string.Equals(direction, "desc", StringComparison.OrdinalIgnoreCase);
+
+        return sort.ToLowerInvariant() switch
+        {
+            "averageguesscount" => descending
+                ? entries.ThenByDescending(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenByDescending(entry => entry.Stats.Wins)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenByDescending(entry => entry.Stats.Wins)
+                    .ThenBy(entry => entry.Player.DisplayName),
+            "wins" => descending
+                ? entries.ThenByDescending(entry => entry.Stats.Wins)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Stats.Wins)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName),
+            "attempts" => descending
+                ? entries.ThenByDescending(entry => entry.Stats.TotalAttempts)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Stats.TotalAttempts)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName),
+            "currentstreak" => descending
+                ? entries.ThenByDescending(entry => entry.Stats.CurrentStreak)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Stats.CurrentStreak)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName),
+            "longeststreak" => descending
+                ? entries.ThenByDescending(entry => entry.Stats.LongestStreak)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Stats.LongestStreak)
+                    .ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenBy(entry => entry.Player.DisplayName),
+            "player" => descending
+                ? entries.ThenByDescending(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.Player.DisplayName),
+            _ => descending
+                ? entries.ThenByDescending(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenByDescending(entry => entry.Stats.Wins)
+                    .ThenBy(entry => entry.Player.DisplayName)
+                : entries.ThenBy(entry => entry.WinRate ?? 0)
+                    .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                    .ThenByDescending(entry => entry.Stats.Wins)
+                    .ThenBy(entry => entry.Player.DisplayName)
+        };
     }
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/StatsController.cs
@@ -100,12 +100,12 @@ public class StatsController(
                     : (double?)null;
                 return new LeaderboardCandidate(player, stats, winRate);
             })
-            .Where(entry => entry.Stats.TotalAttempts > 0)
-            .OrderBy(entry => 0)
-            .ApplyLeaderboardSort(normalizedSort, normalizedDirection)
+            .Where(entry => entry.Stats.TotalAttempts > 0);
+
+        var rankedList = ApplyLeaderboardSort(ranked, normalizedSort, normalizedDirection)
             .ToList();
 
-        var total = ranked.Count;
+        var total = rankedList.Count;
         var totalPages = total == 0 ? 1 : (int)Math.Ceiling((double)total / pageSize);
         page = Math.Min(page, totalPages);
 
@@ -113,7 +113,7 @@ public class StatsController(
         var globalRankStart = (page - 1) * pageSize + 1;
         var rank = globalRankStart;
 
-        foreach (var entry in ranked.Skip((page - 1) * pageSize).Take(pageSize))
+        foreach (var entry in rankedList.Skip((page - 1) * pageSize).Take(pageSize))
         {
             leaderboard.Add(new LeaderboardEntryResponse(
                 rank,
@@ -194,7 +194,7 @@ public class StatsController(
     }
 
     private static IOrderedEnumerable<LeaderboardCandidate> ApplyLeaderboardSort(
-        this IOrderedEnumerable<LeaderboardCandidate> entries,
+        IEnumerable<LeaderboardCandidate> entries,
         string sort,
         string direction)
     {
@@ -203,59 +203,59 @@ public class StatsController(
         return sort.ToLowerInvariant() switch
         {
             "averageguesscount" => descending
-                ? entries.ThenByDescending(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                ? entries.OrderByDescending(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenByDescending(entry => entry.Stats.Wins)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
+                : entries.OrderBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenByDescending(entry => entry.Stats.Wins)
                     .ThenBy(entry => entry.Player.DisplayName),
             "wins" => descending
-                ? entries.ThenByDescending(entry => entry.Stats.Wins)
+                ? entries.OrderByDescending(entry => entry.Stats.Wins)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Stats.Wins)
+                : entries.OrderBy(entry => entry.Stats.Wins)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName),
             "attempts" => descending
-                ? entries.ThenByDescending(entry => entry.Stats.TotalAttempts)
+                ? entries.OrderByDescending(entry => entry.Stats.TotalAttempts)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Stats.TotalAttempts)
+                : entries.OrderBy(entry => entry.Stats.TotalAttempts)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName),
             "currentstreak" => descending
-                ? entries.ThenByDescending(entry => entry.Stats.CurrentStreak)
+                ? entries.OrderByDescending(entry => entry.Stats.CurrentStreak)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Stats.CurrentStreak)
+                : entries.OrderBy(entry => entry.Stats.CurrentStreak)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName),
             "longeststreak" => descending
-                ? entries.ThenByDescending(entry => entry.Stats.LongestStreak)
+                ? entries.OrderByDescending(entry => entry.Stats.LongestStreak)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Stats.LongestStreak)
+                : entries.OrderBy(entry => entry.Stats.LongestStreak)
                     .ThenByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenBy(entry => entry.Player.DisplayName),
             "player" => descending
-                ? entries.ThenByDescending(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.Player.DisplayName),
+                ? entries.OrderByDescending(entry => entry.Player.DisplayName)
+                : entries.OrderBy(entry => entry.Player.DisplayName),
             _ => descending
-                ? entries.ThenByDescending(entry => entry.WinRate ?? 0)
+                ? entries.OrderByDescending(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenByDescending(entry => entry.Stats.Wins)
                     .ThenBy(entry => entry.Player.DisplayName)
-                : entries.ThenBy(entry => entry.WinRate ?? 0)
+                : entries.OrderBy(entry => entry.WinRate ?? 0)
                     .ThenBy(entry => entry.Stats.AverageGuessCount ?? double.MaxValue)
                     .ThenByDescending(entry => entry.Stats.Wins)
                     .ThenBy(entry => entry.Player.DisplayName)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/StatsControllerTests.cs
@@ -65,6 +65,39 @@ public class StatsControllerTests
     }
 
     [Fact]
+    public async Task GetLeaderboard_orders_by_wins_ascending_then_uses_tiebreakers()
+    {
+        var lowWins = CreatePlayer("LowWins");
+        lowWins.Attempts.Add(CreateAttempt(lowWins, new DateOnly(2025, 1, 1), AttemptStatus.Solved, true, 2));
+        lowWins.Attempts.Add(CreateAttempt(lowWins, new DateOnly(2025, 1, 2), AttemptStatus.Failed, true, 4));
+
+        var higherWinRate = CreatePlayer("HigherWinRate");
+        higherWinRate.Attempts.Add(CreateAttempt(higherWinRate, new DateOnly(2025, 1, 1), AttemptStatus.Solved, true, 2));
+        higherWinRate.Attempts.Add(CreateAttempt(higherWinRate, new DateOnly(2025, 1, 2), AttemptStatus.Solved, true, 3));
+
+        var lowerWinRate = CreatePlayer("LowerWinRate");
+        lowerWinRate.Attempts.Add(CreateAttempt(lowerWinRate, new DateOnly(2025, 1, 1), AttemptStatus.Solved, true, 2));
+        lowerWinRate.Attempts.Add(CreateAttempt(lowerWinRate, new DateOnly(2025, 1, 2), AttemptStatus.Solved, true, 4));
+        lowerWinRate.Attempts.Add(CreateAttempt(lowerWinRate, new DateOnly(2025, 1, 3), AttemptStatus.Failed, true, 6));
+
+        var repo = new FakePlayerRepository([higherWinRate, lowerWinRate, lowWins]);
+        var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 4)));
+
+        var result = await controller.GetLeaderboard(
+            sort: "wins",
+            direction: "asc",
+            cancellationToken: CancellationToken.None);
+        var okResult = result.Result as OkObjectResult;
+
+        okResult.Should().NotBeNull();
+        var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;
+
+        payload.Items.Select(item => item.DisplayName)
+            .Should()
+            .Equal("LowWins", "HigherWinRate", "LowerWinRate");
+    }
+
+    [Fact]
     public async Task GetPlayers_respects_easy_mode_and_after_reveal_filters()
     {
         var easyPlayer = CreatePlayer("Easy");
@@ -132,7 +165,7 @@ public class StatsControllerTests
         var repo = new FakePlayerRepository(players);
         var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 6)));
 
-        var result = await controller.GetLeaderboard(page: 2, pageSize: 2, CancellationToken.None);
+        var result = await controller.GetLeaderboard(page: 2, pageSize: 2, cancellationToken: CancellationToken.None);
         var okResult = result.Result as OkObjectResult;
 
         okResult.Should().NotBeNull();
@@ -157,7 +190,7 @@ public class StatsControllerTests
         var repo = new FakePlayerRepository([player]);
         var controller = new StatsController(repo, new PlayerStatisticsService(), new FakeGameClock(new DateOnly(2025, 1, 2)));
 
-        var result = await controller.GetLeaderboard(page: 99, pageSize: 10, CancellationToken.None);
+        var result = await controller.GetLeaderboard(page: 99, pageSize: 10, cancellationToken: CancellationToken.None);
         var okResult = result.Result as OkObjectResult;
 
         var payload = okResult!.Value.Should().BeOfType<LeaderboardPageResponse>().Subject;

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/StatsService.ts
@@ -43,17 +43,23 @@ export class StatsService {
 	 */
 	public static getApiStatsLeaderboard({
 		page = 1,
-		pageSize = 10
+		pageSize = 10,
+		sort = 'winRate',
+		direction = 'desc'
 	}: {
 		page?: number;
 		pageSize?: number;
+		sort?: string;
+		direction?: string;
 	}): CancelablePromise<LeaderboardPageResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
 			url: '/api/stats/leaderboard',
 			query: {
 				page: page,
-				pageSize: pageSize
+				pageSize: pageSize,
+				sort: sort,
+				direction: direction
 			}
 		});
 	}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/leaderboard/+page.svelte
@@ -41,6 +41,8 @@
 	let todayEntries = $state<TodayLeaderboardEntryResponse[]>([]);
 	let hasLoaded = $state(false);
 	let activeTab = $state<LeaderboardTab>('all-time');
+	let leaderboardSort = $state('winRate');
+	let leaderboardDirection = $state<'asc' | 'desc'>('desc');
 	let loadedTabs = $state<Record<LeaderboardTab, boolean>>({
 		'all-time': false,
 		today: false
@@ -79,7 +81,12 @@
 		loading = true;
 		error = null;
 		try {
-			const data = await StatsService.getApiStatsLeaderboard({ page, pageSize: PAGE_SIZE });
+			const data = await StatsService.getApiStatsLeaderboard({
+				page,
+				pageSize: PAGE_SIZE,
+				sort: leaderboardSort,
+				direction: leaderboardDirection
+			});
 			allTimeEntries = data.items ?? [];
 			allTimePage = data.page ?? 1;
 			allTimeTotalPages = data.totalPages ?? 1;
@@ -115,6 +122,16 @@
 
 	async function goToPage(page: number) {
 		await loadAllTime(page);
+	}
+
+	async function sortLeaderboard(sort: 'winRate' | 'averageGuessCount' | 'wins' | 'attempts' | 'currentStreak') {
+		if (leaderboardSort === sort) {
+			leaderboardDirection = leaderboardDirection === 'asc' ? 'desc' : 'asc';
+		} else {
+			leaderboardSort = sort;
+			leaderboardDirection = sort === 'averageGuessCount' ? 'asc' : 'desc';
+		}
+		await loadAllTime(1);
 	}
 
 	async function selectTab(tab: LeaderboardTab) {
@@ -234,11 +251,31 @@
 						<tr>
 							<th class="px-6 py-4">Rank</th>
 							<th class="px-6 py-4">Player</th>
-							<th class="px-6 py-4">Win rate</th>
-							<th class="px-6 py-4">Avg guesses</th>
-							<th class="px-6 py-4">Wins</th>
-							<th class="px-6 py-4">Attempts</th>
-							<th class="px-6 py-4">Current streak</th>
+							<th class="px-6 py-4">
+								<button type="button" class="hover:text-white" on:click={() => void sortLeaderboard('winRate')}>
+									Win rate {leaderboardSort === 'winRate' ? (leaderboardDirection === 'asc' ? '▲' : '▼') : ''}
+								</button>
+							</th>
+							<th class="px-6 py-4">
+								<button type="button" class="hover:text-white" on:click={() => void sortLeaderboard('averageGuessCount')}>
+									Avg guesses {leaderboardSort === 'averageGuessCount' ? (leaderboardDirection === 'asc' ? '▲' : '▼') : ''}
+								</button>
+							</th>
+							<th class="px-6 py-4">
+								<button type="button" class="hover:text-white" on:click={() => void sortLeaderboard('wins')}>
+									Wins {leaderboardSort === 'wins' ? (leaderboardDirection === 'asc' ? '▲' : '▼') : ''}
+								</button>
+							</th>
+							<th class="px-6 py-4">
+								<button type="button" class="hover:text-white" on:click={() => void sortLeaderboard('attempts')}>
+									Attempts {leaderboardSort === 'attempts' ? (leaderboardDirection === 'asc' ? '▲' : '▼') : ''}
+								</button>
+							</th>
+							<th class="px-6 py-4">
+								<button type="button" class="hover:text-white" on:click={() => void sortLeaderboard('currentStreak')}>
+									Current streak {leaderboardSort === 'currentStreak' ? (leaderboardDirection === 'asc' ? '▲' : '▼') : ''}
+								</button>
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/leaderboard.spec.ts
@@ -72,3 +72,58 @@ test('leaderboard shows ranked hard mode entries', async ({ page }) => {
 	await expect(page.getByRole('cell', { name: 'Challenger' })).toBeVisible();
 	await expect(page.getByRole('cell', { name: '1' })).toBeVisible();
 });
+
+test('leaderboard can be resorted by column', async ({ page }) => {
+	let sortQueries: Array<Record<string, string | string[] | undefined>> = [];
+
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				id: '11111111-1111-1111-1111-111111111111',
+				displayName: 'Tester',
+				email: 'tester@example.com',
+				createdOn: '2025-01-01T00:00:00Z'
+			})
+		});
+	});
+
+	await page.route('**/api/stats/leaderboard**', async (route) => {
+		const query = route.request().url();
+		sortQueries.push(Object.fromEntries(new URL(query).searchParams.entries()));
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				items: [
+					{
+						rank: 1,
+						playerId: '22222222-2222-2222-2222-222222222222',
+						displayName: 'Rival',
+						totalAttempts: 5,
+						wins: 4,
+						failures: 1,
+						currentStreak: 4,
+						longestStreak: 5,
+						practiceAttempts: 0,
+						averageGuessCount: 3,
+						winRate: 0.8
+					}
+				],
+				total: 1,
+				page: 1,
+				pageSize: 10,
+				totalPages: 1
+			})
+		});
+	});
+
+	await page.goto('/leaderboard', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+	await page.getByRole('button', { name: /Avg guesses/ }).click();
+
+	await expect(page.getByRole('cell', { name: 'Rival' })).toBeVisible();
+	expect(sortQueries.at(-1)?.sort).toBe('averageGuessCount');
+	expect(sortQueries.at(-1)?.direction).toBe('asc');
+});


### PR DESCRIPTION
Closes #118\n\nAdds sortable headers to the all-time leaderboard and wires the sort params through the API/client.