### PR TITLE
Add replay mode for historical puzzles (#28)

### DIFF
--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Controllers/GameController.cs
@@ -18,7 +18,7 @@ public class GameController(
     ILogger<GameController> logger) : ControllerBase
 {
     [HttpGet("state")]
-    public async Task<ActionResult<GameStateResponse>> GetState(CancellationToken cancellationToken)
+    public async Task<ActionResult<GameStateResponse>> GetState([FromQuery] DateOnly? date = null, CancellationToken cancellationToken = default)
     {
         var playerId = GetPlayerId();
         if (playerId is null)
@@ -28,17 +28,25 @@ public class GameController(
 
         try
         {
-            var state = await gameplayService.GetState(playerId.Value, cancellationToken);
+            var state = await gameplayService.GetState(playerId.Value, date, cancellationToken);
             return Ok(MapState(state));
         }
         catch (DailyPuzzleUnavailableException ex)
         {
             return PuzzleUnavailable(ex.Message);
         }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new ProblemDetails { Status = StatusCodes.Status404NotFound, Detail = ex.Message });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
+        }
     }
 
     [HttpPost("guess")]
-    public async Task<ActionResult<GameStateResponse>> SubmitGuess([FromBody] SubmitGuessRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<GameStateResponse>> SubmitGuess([FromBody] SubmitGuessRequest request, [FromQuery] DateOnly? date = null, CancellationToken cancellationToken = default)
     {
         var playerId = GetPlayerId();
         if (playerId is null)
@@ -48,13 +56,17 @@ public class GameController(
 
         try
         {
-            var state = await gameplayService.SubmitGuess(playerId.Value, request.Guess, cancellationToken);
+            var state = await gameplayService.SubmitGuess(playerId.Value, request.Guess, date, cancellationToken);
             logger.LogInformation("Guess submitted. PlayerId={PlayerId} PuzzleDate={PuzzleDate}", playerId, state.Puzzle.PuzzleDate);
             return Ok(MapState(state));
         }
         catch (DailyPuzzleUnavailableException ex)
         {
             return PuzzleUnavailable(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new ProblemDetails { Status = StatusCodes.Status404NotFound, Detail = ex.Message });
         }
         catch (ArgumentException ex)
         {
@@ -71,7 +83,7 @@ public class GameController(
     }
 
     [HttpPost("easy-mode")]
-    public async Task<ActionResult<GameStateResponse>> EnableEasyMode(CancellationToken cancellationToken)
+    public async Task<ActionResult<GameStateResponse>> EnableEasyMode([FromQuery] DateOnly? date = null, CancellationToken cancellationToken = default)
     {
         var playerId = GetPlayerId();
         if (playerId is null)
@@ -81,13 +93,21 @@ public class GameController(
 
         try
         {
-            var state = await gameplayService.EnableEasyMode(playerId.Value, cancellationToken);
+            var state = await gameplayService.EnableEasyMode(playerId.Value, date, cancellationToken);
             logger.LogInformation("Easy mode enabled. PlayerId={PlayerId}", playerId);
             return Ok(MapState(state));
         }
         catch (DailyPuzzleUnavailableException ex)
         {
             return PuzzleUnavailable(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new ProblemDetails { Status = StatusCodes.Status404NotFound, Detail = ex.Message });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails { Status = StatusCodes.Status400BadRequest, Detail = ex.Message });
         }
         catch (DuplicatePuzzleAttemptException ex)
         {
@@ -177,7 +197,8 @@ public class GameController(
             isHardMode,
             canGuess,
             attemptResponse,
-            solution);
+            solution,
+            state.IsReplay);
     }
 
     private SolutionsResponse MapSolutions(SolutionsSnapshot snapshot)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/GameStateResponse.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Api/Models/Game/GameStateResponse.cs
@@ -10,4 +10,5 @@ public record GameStateResponse(
     bool IsHardMode,
     bool CanGuess,
     AttemptResponse? Attempt,
-    string? Solution);
+    string? Solution,
+    bool IsReplay = false);

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/GameplayService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Application/Services/Game/GameplayService.cs
@@ -15,9 +15,15 @@ public class GameplayService(
     private readonly GameOptions _options = options;
     private readonly IGuessEvaluationService _guessEvaluationService = guessEvaluationService;
 
-    public async Task<GameplayState> GetState(Guid playerId, CancellationToken cancellationToken = default)
+    public async Task<GameplayState> GetState(Guid playerId, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default)
     {
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
+        var isReplay = puzzleDate.HasValue && puzzleDate.Value != gameClock.Today;
+        var targetDate = puzzleDate ?? gameClock.Today;
+
+        var puzzle = isReplay
+            ? await GetExistingPuzzle(targetDate, cancellationToken)
+            : await puzzleService.GetOrCreatePuzzle(targetDate, PuzzleStream.NewYorkTimes, cancellationToken);
+
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
 
         var cutoffPassed = gameClock.HasRevealPassed(puzzle.PuzzleDate);
@@ -30,13 +36,19 @@ public class GameplayService(
             solutionRevealed,
             AllowLatePlay: true,
             _options.WordLength,
-            _options.MaxGuesses);
+            _options.MaxGuesses,
+            IsReplay: isReplay);
     }
 
-    public async Task<GameplayState> SubmitGuess(Guid playerId, string guessWord, CancellationToken cancellationToken = default)
+    public async Task<GameplayState> SubmitGuess(Guid playerId, string guessWord, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default)
     {
+        var isReplay = puzzleDate.HasValue && puzzleDate.Value != gameClock.Today;
+        var targetDate = puzzleDate ?? gameClock.Today;
         var normalizedGuess = _guessEvaluationService.NormalizeGuess(guessWord);
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
+
+        var puzzle = isReplay
+            ? await GetExistingPuzzle(targetDate, cancellationToken)
+            : await puzzleService.GetOrCreatePuzzle(targetDate, PuzzleStream.NewYorkTimes, cancellationToken);
 
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
         if (attempt is null)
@@ -117,12 +129,19 @@ public class GameplayService(
             solutionRevealed,
             AllowLatePlay: true,
             _options.WordLength,
-            _options.MaxGuesses);
+            _options.MaxGuesses,
+            IsReplay: isReplay);
     }
 
-    public async Task<GameplayState> EnableEasyMode(Guid playerId, CancellationToken cancellationToken = default)
+    public async Task<GameplayState> EnableEasyMode(Guid playerId, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default)
     {
-        var puzzle = await puzzleService.GetOrCreatePuzzle(gameClock.Today, PuzzleStream.NewYorkTimes, cancellationToken);
+        var isReplay = puzzleDate.HasValue && puzzleDate.Value != gameClock.Today;
+        var targetDate = puzzleDate ?? gameClock.Today;
+
+        var puzzle = isReplay
+            ? await GetExistingPuzzle(targetDate, cancellationToken)
+            : await puzzleService.GetOrCreatePuzzle(targetDate, PuzzleStream.NewYorkTimes, cancellationToken);
+
         var attempt = await LoadAttempt(playerId, puzzle.Id, cancellationToken);
 
         if (attempt is null)
@@ -159,7 +178,8 @@ public class GameplayService(
             solutionRevealed,
             AllowLatePlay: true,
             _options.WordLength,
-            _options.MaxGuesses);
+            _options.MaxGuesses,
+            IsReplay: isReplay);
     }
 
     public async Task<SolutionsSnapshot> GetSolutions(CancellationToken cancellationToken = default)
@@ -170,6 +190,22 @@ public class GameplayService(
         var attempts = await gameRepository.GetAttemptsForPuzzle(puzzle.Id, cancellationToken);
 
         return new SolutionsSnapshot(puzzle, cutoffPassed, attempts);
+    }
+
+    private async Task<DailyPuzzle> GetExistingPuzzle(DateOnly date, CancellationToken cancellationToken)
+    {
+        if (date > gameClock.Today)
+        {
+            throw new ArgumentException("Cannot replay a puzzle from the future.");
+        }
+
+        var puzzle = await gameRepository.GetPuzzleByDate(date, PuzzleStream.NewYorkTimes, cancellationToken);
+        if (puzzle is null)
+        {
+            throw new KeyNotFoundException($"No puzzle found for {date:yyyy-MM-dd}.");
+        }
+
+        return puzzle;
     }
 
     private async Task<PlayerPuzzleAttempt?> LoadAttempt(Guid playerId, Guid puzzleId, CancellationToken cancellationToken)

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/GameplayState.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/GameplayState.cs
@@ -9,7 +9,8 @@ public record GameplayState(
     bool SolutionRevealed,
     bool AllowLatePlay,
     int WordLength,
-    int MaxGuesses);
+    int MaxGuesses,
+    bool IsReplay = false);
 
 public record SolutionsSnapshot(
     DailyPuzzle Puzzle,

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/IGameplayService.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Domain/Services/Game/IGameplayService.cs
@@ -2,8 +2,8 @@ namespace Wordle.TrackerSupreme.Domain.Services.Game;
 
 public interface IGameplayService
 {
-    Task<GameplayState> GetState(Guid playerId, CancellationToken cancellationToken = default);
-    Task<GameplayState> SubmitGuess(Guid playerId, string guessWord, CancellationToken cancellationToken = default);
-    Task<GameplayState> EnableEasyMode(Guid playerId, CancellationToken cancellationToken = default);
+    Task<GameplayState> GetState(Guid playerId, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default);
+    Task<GameplayState> SubmitGuess(Guid playerId, string guessWord, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default);
+    Task<GameplayState> EnableEasyMode(Guid playerId, DateOnly? puzzleDate = null, CancellationToken cancellationToken = default);
     Task<SolutionsSnapshot> GetSolutions(CancellationToken cancellationToken = default);
 }

--- a/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
+++ b/src/Wordle.TrackerSupreme.BackEnd/Wordle.TrackerSupreme.Tests/GameControllerTests.cs
@@ -58,7 +58,7 @@ public class GameControllerTests
         var repo = new FakeGameRepository();
         var controller = CreateController(repo, clock);
 
-        var result = await controller.GetState(CancellationToken.None);
+        var result = await controller.GetState(null, CancellationToken.None);
 
         result.Result.Should().BeOfType<OkObjectResult>();
         var state = (result.Result as OkObjectResult)!.Value as Api.Models.Game.GameStateResponse;
@@ -76,7 +76,7 @@ public class GameControllerTests
         var failingProvider = new FakeOfficialWordProvider((_, _) => throw new InvalidOperationException("boom"));
         var controller = CreateController(repo, clock, officialWordProvider: failingProvider);
 
-        var result = await controller.GetState(CancellationToken.None);
+        var result = await controller.GetState(null, CancellationToken.None);
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Which;
         objectResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
@@ -91,8 +91,8 @@ public class GameControllerTests
         var repo = new FakeGameRepository();
         var controller = CreateController(repo, clock, "PLANT");
 
-        await controller.SubmitGuess(new Api.Models.Game.SubmitGuessRequest { Guess = "PLANT" }, CancellationToken.None);
-        var second = await controller.SubmitGuess(new Api.Models.Game.SubmitGuessRequest { Guess = "PLANT" }, CancellationToken.None);
+        await controller.SubmitGuess(new Api.Models.Game.SubmitGuessRequest { Guess = "PLANT" }, null, CancellationToken.None);
+        var second = await controller.SubmitGuess(new Api.Models.Game.SubmitGuessRequest { Guess = "PLANT" }, null, CancellationToken.None);
 
         second.Result.Should().BeOfType<ConflictObjectResult>();
     }
@@ -107,6 +107,7 @@ public class GameControllerTests
 
         var result = await controller.SubmitGuess(
             new Api.Models.Game.SubmitGuessRequest { Guess = "ZZZZZ" },
+            null,
             CancellationToken.None);
 
         result.Result.Should().BeOfType<BadRequestObjectResult>();
@@ -124,6 +125,7 @@ public class GameControllerTests
 
         var result = await controller.SubmitGuess(
             new Api.Models.Game.SubmitGuessRequest { Guess = "CRANE" },
+            null,
             CancellationToken.None);
 
         var conflict = result.Result.Should().BeOfType<ConflictObjectResult>().Which;
@@ -138,12 +140,103 @@ public class GameControllerTests
         var repo = new FakeGameRepository();
         var controller = CreateController(repo, clock, "CRANE");
 
-        var result = await controller.EnableEasyMode(CancellationToken.None);
+        var result = await controller.EnableEasyMode(null, CancellationToken.None);
 
         result.Result.Should().BeOfType<OkObjectResult>();
         var state = (result.Result as OkObjectResult)!.Value as Api.Models.Game.GameStateResponse;
         state.Should().NotBeNull();
         state!.IsHardMode.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetState_returns_replay_for_existing_past_puzzle()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 20));
+        var repo = new FakeGameRepository();
+        var puzzle = new DailyPuzzle
+        {
+            Id = Guid.NewGuid(),
+            PuzzleDate = new DateOnly(2025, 1, 5),
+            Solution = "GHOST",
+            Stream = PuzzleStream.NewYorkTimes
+        };
+        await repo.AddPuzzle(puzzle, CancellationToken.None);
+        var controller = CreateController(repo, clock, "GHOST");
+
+        var result = await controller.GetState(puzzle.PuzzleDate, CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var state = (result.Result as OkObjectResult)!.Value as Api.Models.Game.GameStateResponse;
+        state.Should().NotBeNull();
+        state!.PuzzleDate.Should().Be(puzzle.PuzzleDate);
+        state.IsReplay.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetState_returns_not_found_when_no_puzzle_exists_for_date()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 20));
+        var repo = new FakeGameRepository();
+        var controller = CreateController(repo, clock);
+
+        var result = await controller.GetState(new DateOnly(2024, 12, 1), CancellationToken.None);
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetState_returns_bad_request_for_future_date()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 20));
+        var repo = new FakeGameRepository();
+        var controller = CreateController(repo, clock);
+
+        var result = await controller.GetState(new DateOnly(2025, 1, 25), CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetState_for_today_does_not_flag_replay()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 20));
+        var repo = new FakeGameRepository();
+        var controller = CreateController(repo, clock);
+
+        var result = await controller.GetState(clock.Today, CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var state = (result.Result as OkObjectResult)!.Value as Api.Models.Game.GameStateResponse;
+        state.Should().NotBeNull();
+        state!.IsReplay.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SubmitGuess_persists_replay_attempt_against_past_puzzle()
+    {
+        var clock = new FakeGameClock(new DateOnly(2025, 1, 20));
+        var repo = new FakeGameRepository();
+        var puzzle = new DailyPuzzle
+        {
+            Id = Guid.NewGuid(),
+            PuzzleDate = new DateOnly(2025, 1, 5),
+            Solution = "GHOST",
+            Stream = PuzzleStream.NewYorkTimes
+        };
+        await repo.AddPuzzle(puzzle, CancellationToken.None);
+        var controller = CreateController(repo, clock, "GHOST");
+
+        var result = await controller.SubmitGuess(
+            new Api.Models.Game.SubmitGuessRequest { Guess = "GHOST" },
+            puzzle.PuzzleDate,
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var state = (result.Result as OkObjectResult)!.Value as Api.Models.Game.GameStateResponse;
+        state.Should().NotBeNull();
+        state!.IsReplay.Should().BeTrue();
+        state.PuzzleDate.Should().Be(puzzle.PuzzleDate);
+        repo.Attempts.Should().ContainSingle(a => a.DailyPuzzleId == puzzle.Id);
     }
 
     [Fact]

--- a/src/Wordle.TrackerSupreme.Web/openapi.json
+++ b/src/Wordle.TrackerSupreme.Web/openapi.json
@@ -529,6 +529,17 @@
 		"/api/game/state": {
 			"get": {
 				"tags": ["Game"],
+				"parameters": [
+					{
+						"name": "date",
+						"in": "query",
+						"schema": {
+							"type": "string",
+							"format": "date",
+							"nullable": true
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -566,6 +577,17 @@
 		"/api/game/guess": {
 			"post": {
 				"tags": ["Game"],
+				"parameters": [
+					{
+						"name": "date",
+						"in": "query",
+						"schema": {
+							"type": "string",
+							"format": "date",
+							"nullable": true
+						}
+					}
+				],
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -642,6 +664,17 @@
 		"/api/game/easy-mode": {
 			"post": {
 				"tags": ["Game"],
+				"parameters": [
+					{
+						"name": "date",
+						"in": "query",
+						"schema": {
+							"type": "string",
+							"format": "date",
+							"nullable": true
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -1136,6 +1169,9 @@
 					"solution": {
 						"type": "string",
 						"nullable": true
+					},
+					"isReplay": {
+						"type": "boolean"
 					}
 				},
 				"additionalProperties": false

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/GameStateResponse.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/models/GameStateResponse.ts
@@ -14,4 +14,5 @@ export type GameStateResponse = {
 	canGuess?: boolean;
 	attempt?: AttemptResponse | null;
 	solution?: string | null;
+	isReplay?: boolean;
 };

--- a/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/GameService.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/api-client/services/GameService.ts
@@ -13,10 +13,17 @@ export class GameService {
 	 * @returns GameStateResponse OK
 	 * @throws ApiError
 	 */
-	public static getApiGameState(): CancelablePromise<GameStateResponse> {
+	public static getApiGameState({
+		date
+	}: {
+		date?: string | null;
+	}): CancelablePromise<GameStateResponse> {
 		return __request(OpenAPI, {
 			method: 'GET',
 			url: '/api/game/state',
+			query: {
+				date: date
+			},
 			errors: {
 				503: `Service Unavailable`
 			}
@@ -27,13 +34,18 @@ export class GameService {
 	 * @throws ApiError
 	 */
 	public static postApiGameGuess({
+		date,
 		requestBody
 	}: {
+		date?: string | null;
 		requestBody?: SubmitGuessRequest;
 	}): CancelablePromise<GameStateResponse> {
 		return __request(OpenAPI, {
 			method: 'POST',
 			url: '/api/game/guess',
+			query: {
+				date: date
+			},
 			body: requestBody,
 			mediaType: 'application/json',
 			errors: {
@@ -47,10 +59,17 @@ export class GameService {
 	 * @returns GameStateResponse OK
 	 * @throws ApiError
 	 */
-	public static postApiGameEasyMode(): CancelablePromise<GameStateResponse> {
+	public static postApiGameEasyMode({
+		date
+	}: {
+		date?: string | null;
+	}): CancelablePromise<GameStateResponse> {
 		return __request(OpenAPI, {
 			method: 'POST',
 			url: '/api/game/easy-mode',
+			query: {
+				date: date
+			},
 			errors: {
 				409: `Conflict`,
 				503: `Service Unavailable`

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.spec.ts
@@ -156,4 +156,43 @@ describe('api helpers', () => {
 		expect((init as RequestInit)?.method).toBe('POST');
 		expect((init as RequestInit)?.body).toBe(JSON.stringify({ guess: 'CRANE' }));
 	});
+
+	it('appends the date query string when fetching a replay state', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve({ puzzleDate: '2025-04-01', isReplay: true })
+		} as Response;
+		const fetchSpy = vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await fetchGameState('2025-04-01');
+
+		expect(fetchSpy.mock.calls[0][0]).toBe('http://api.test/api/game/state?date=2025-04-01');
+	});
+
+	it('appends the date query string when submitting a replay guess', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve({ puzzleDate: '2025-04-01', isReplay: true })
+		} as Response;
+		const fetchSpy = vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await submitGuess('CRANE', '2025-04-01');
+
+		expect(fetchSpy.mock.calls[0][0]).toBe('http://api.test/api/game/guess?date=2025-04-01');
+	});
+
+	it('appends the date query string when enabling easy mode for a replay', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve({ puzzleDate: '2025-04-01', isReplay: true, isHardMode: false })
+		} as Response;
+		const fetchSpy = vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(mockResponse);
+
+		await enableEasyMode('2025-04-01');
+
+		expect(fetchSpy.mock.calls[0][0]).toBe('http://api.test/api/game/easy-mode?date=2025-04-01');
+	});
 });

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/api.ts
@@ -54,19 +54,23 @@ async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
 	return (await response.json()) as T;
 }
 
-export function fetchGameState(): Promise<GameStateResponse> {
-	return apiFetch<GameStateResponse>('/api/game/state');
+function dateQuery(date?: string): string {
+	return date ? `?date=${date}` : '';
 }
 
-export function submitGuess(guess: string): Promise<GameStateResponse> {
-	return apiFetch<GameStateResponse>('/api/game/guess', {
+export function fetchGameState(date?: string): Promise<GameStateResponse> {
+	return apiFetch<GameStateResponse>(`/api/game/state${dateQuery(date)}`);
+}
+
+export function submitGuess(guess: string, date?: string): Promise<GameStateResponse> {
+	return apiFetch<GameStateResponse>(`/api/game/guess${dateQuery(date)}`, {
 		method: 'POST',
 		body: JSON.stringify({ guess })
 	});
 }
 
-export function enableEasyMode(): Promise<GameStateResponse> {
-	return apiFetch<GameStateResponse>('/api/game/easy-mode', {
+export function enableEasyMode(date?: string): Promise<GameStateResponse> {
+	return apiFetch<GameStateResponse>(`/api/game/easy-mode${dateQuery(date)}`, {
 		method: 'POST'
 	});
 }

--- a/src/Wordle.TrackerSupreme.Web/src/lib/game/types.ts
+++ b/src/Wordle.TrackerSupreme.Web/src/lib/game/types.ts
@@ -33,6 +33,7 @@ export type GameStateResponse = {
 	canGuess: boolean;
 	attempt?: AttemptResponse | null;
 	solution?: string | null;
+	isReplay?: boolean;
 };
 
 export type SolutionEntry = {

--- a/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/+layout.svelte
@@ -63,6 +63,9 @@
 						class="hidden items-center gap-4 text-xs font-semibold tracking-[0.2em] text-slate-200/70 uppercase md:flex"
 					>
 						<a href={resolve('/')} class="transition hover:text-white">Play</a>
+						<a href={resolve('/replay')} class="transition hover:text-white" data-testid="nav-replay"
+							>Replay</a
+						>
 						<a href={resolve('/stats')} class="transition hover:text-white">Stats</a>
 						<a href={resolve('/leaderboard')} class="transition hover:text-white">Leaderboard</a>
 						{#if $auth.user?.isAdmin}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/replay/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/replay/+page.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { auth } from '$lib/auth/store';
+	import { onMount } from 'svelte';
+
+	let checking = $state(true);
+	let selectedDate = $state('');
+	let error = $state<string | null>(null);
+	const today = new Date().toISOString().slice(0, 10);
+
+	onMount(() => {
+		const unsubscribe = auth.subscribe((current) => {
+			if (!current.ready) {
+				return;
+			}
+			checking = false;
+			if (!current.user) {
+				goto(resolve('/signin'));
+			}
+		});
+		return () => unsubscribe();
+	});
+
+	function isValidDate(value: string): boolean {
+		if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+		const parsed = new Date(value);
+		return !Number.isNaN(parsed.getTime()) && value <= today;
+	}
+
+	function handleSubmit(event: Event) {
+		event.preventDefault();
+		error = null;
+		if (!selectedDate) {
+			error = 'Pick a date to replay.';
+			return;
+		}
+		if (!isValidDate(selectedDate)) {
+			error = 'Pick a date that is today or earlier.';
+			return;
+		}
+		goto(resolve(`/replay/${selectedDate}`));
+	}
+</script>
+
+{#if checking}
+	<div
+		class="rounded-2xl border border-white/10 bg-white/5 p-10 text-center text-slate-200/80 shadow-xl"
+	>
+		Checking your session...
+	</div>
+{:else if $auth.user}
+	<section class="mx-auto max-w-xl space-y-6">
+		<header class="space-y-2">
+			<p class="text-sm tracking-[0.2em] text-cyan-200/80 uppercase">Replay</p>
+			<h1 class="text-3xl font-semibold text-white">Play a past puzzle</h1>
+			<p class="text-sm text-slate-200/80">
+				Pick a date to revisit any historical Wordle Tracker Supreme puzzle. Replays are tracked as
+				practice and won't change your streak or leaderboard rank.
+			</p>
+		</header>
+		<form
+			class="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl"
+			onsubmit={handleSubmit}
+			data-testid="replay-form"
+		>
+			<label class="block space-y-2 text-sm text-slate-200/80">
+				<span class="text-xs font-semibold tracking-[0.2em] text-slate-200/60 uppercase">
+					Puzzle date
+				</span>
+				<input
+					type="date"
+					bind:value={selectedDate}
+					max={today}
+					required
+					class="block w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-base text-white transition outline-none focus:border-cyan-300/60"
+					data-testid="replay-date"
+				/>
+			</label>
+			{#if error}
+				<p class="text-sm text-rose-200" data-testid="replay-error">{error}</p>
+			{/if}
+			<button
+				type="submit"
+				class="w-full rounded-full bg-emerald-400 px-4 py-3 font-semibold text-slate-900 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+				disabled={!selectedDate}
+				data-testid="replay-submit"
+			>
+				Play this puzzle
+			</button>
+		</form>
+		<p class="text-center text-xs text-slate-200/60">
+			Looking for today's puzzle?
+			<a
+				href={resolve('/')}
+				class="ml-1 underline decoration-slate-300/40 underline-offset-4 transition hover:text-white"
+			>
+				Play today
+			</a>
+		</p>
+	</section>
+{/if}

--- a/src/Wordle.TrackerSupreme.Web/src/routes/replay/[date]/+page.svelte
+++ b/src/Wordle.TrackerSupreme.Web/src/routes/replay/[date]/+page.svelte
@@ -1,0 +1,634 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { resolve } from '$app/paths';
+	import { auth } from '$lib/auth/store';
+	import { ApiResponseError, enableEasyMode, fetchGameState, submitGuess } from '$lib/game/api';
+	import { describeTileForScreenReader } from '$lib/game/accessibility';
+	import { getRevealDurationMs, shouldTriggerSolveCelebration } from '$lib/game/celebration';
+	import {
+		buildConfettiPieces,
+		defaultConfettiPieceCount,
+		type ConfettiPiece
+	} from '$lib/game/confetti';
+	import { getKeyboardLetterState } from '$lib/game/keyboard';
+	import type { GameStateResponse, GuessResponse, LetterResult } from '$lib/game/types';
+	import { onMount, tick } from 'svelte';
+
+	let checking = true;
+	let loadingState = true;
+	let state: GameStateResponse | null = null;
+	let guess = '';
+	let message: string | null = null;
+	let error: string | null = null;
+	let puzzleNotFound = false;
+	let initialized = false;
+	let submitting = false;
+	let animatedGuessId: string | null = null;
+	let showConfetti = false;
+	let confettiPieces: ConfettiPiece[] = [];
+	let confettiTimer: ReturnType<typeof setTimeout> | null = null;
+	let shakingRow: number | null = null;
+	let shakeTimer: ReturnType<typeof setTimeout> | null = null;
+	let announcement: string | null = null;
+	let announcementIsError = false;
+	const keyboardRows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
+	const confettiDurationMs = 1200;
+
+	$: puzzleDate = $page.params.date;
+
+	onMount(() => {
+		const unsubscribe = auth.subscribe(async (current) => {
+			if (!current.ready) {
+				return;
+			}
+			checking = false;
+
+			if (!current.user) {
+				goto(resolve('/signin'));
+				return;
+			}
+
+			if (!initialized) {
+				initialized = true;
+				await loadState();
+			}
+		});
+
+		const keyHandler = (evt: KeyboardEvent) => {
+			if (!state) {
+				return;
+			}
+			if (evt.key === 'Enter') {
+				evt.preventDefault();
+				void handleGuess();
+				return;
+			}
+			if (evt.key === 'Backspace') {
+				evt.preventDefault();
+				removeLetter();
+				return;
+			}
+			if (/^[a-zA-Z]$/.test(evt.key)) {
+				evt.preventDefault();
+				pushLetter(evt.key.toUpperCase());
+			}
+		};
+
+		window.addEventListener('keydown', keyHandler);
+		return () => {
+			window.removeEventListener('keydown', keyHandler);
+			unsubscribe();
+		};
+	});
+
+	$: guessInputLocked = !state || !state.canGuess || submitting;
+	$: announcement = error ?? message;
+	$: announcementIsError = error !== null;
+
+	async function loadState() {
+		loadingState = true;
+		error = null;
+		puzzleNotFound = false;
+		animatedGuessId = null;
+		try {
+			state = await fetchGameState(puzzleDate);
+			message = completedMessage(state);
+		} catch (err) {
+			if (err instanceof ApiResponseError && err.status === 404) {
+				puzzleNotFound = true;
+			} else if (
+				err instanceof ApiResponseError &&
+				err.status === 503 &&
+				err.code === 'puzzle_unavailable'
+			) {
+				puzzleNotFound = true;
+			} else {
+				error = err instanceof Error ? err.message : 'Unable to load this puzzle.';
+			}
+		} finally {
+			loadingState = false;
+		}
+	}
+
+	function triggerShake() {
+		if (shakeTimer) clearTimeout(shakeTimer);
+		shakingRow = state?.attempt?.guesses.length ?? 0;
+		shakeTimer = setTimeout(() => {
+			shakingRow = null;
+			shakeTimer = null;
+		}, 600);
+	}
+
+	function completedMessage(s: GameStateResponse | null): string | null {
+		if (!s?.attempt) return null;
+		const guessCount = s.attempt.guesses.length;
+		if (s.attempt.status === 'Solved') {
+			return `You solved it in ${guessCount} ${guessCount === 1 ? 'guess' : 'guesses'}!`;
+		}
+		if (s.attempt.status === 'Failed') {
+			const word = s.solutionRevealed ? ` The word was ${s.solution}.` : '';
+			return `No more guesses!${word}`;
+		}
+		return null;
+	}
+
+	async function handleGuess() {
+		if (isGuessInputLocked()) {
+			return;
+		}
+
+		const currentState = state!;
+		const targetLength = currentState.wordLength ?? 5;
+		const normalized = guess.trim().toUpperCase();
+
+		if (normalized.length !== targetLength) {
+			error = `Guesses must be ${targetLength} letters.`;
+			triggerShake();
+			return;
+		}
+
+		error = null;
+		message = null;
+		const previousStatus = currentState.attempt?.status ?? null;
+		const previousGuessId = currentState.attempt?.guesses.at(-1)?.guessId ?? null;
+		submitting = true;
+		await tick();
+		try {
+			state = await submitGuess(normalized, puzzleDate);
+			const latestGuessId = state.attempt?.guesses.at(-1)?.guessId ?? null;
+			animatedGuessId = latestGuessId !== previousGuessId ? latestGuessId : null;
+			guess = '';
+			message = null;
+			const nextStatus = state.attempt?.status ?? null;
+			if (shouldTriggerSolveCelebration(previousStatus, nextStatus)) {
+				void triggerSolveCelebration();
+			}
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Unable to submit guess.';
+			triggerShake();
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function isGuessInputLocked() {
+		return !state || !state.canGuess || submitting;
+	}
+
+	function pushLetter(letter: string) {
+		if (isGuessInputLocked()) {
+			return;
+		}
+		const currentState = state!;
+		if (guess.length >= currentState.wordLength) {
+			return;
+		}
+		guess = `${guess}${letter}`;
+	}
+
+	function removeLetter() {
+		if (!state || !guess.length || submitting) {
+			return;
+		}
+		guess = guess.slice(0, -1);
+	}
+
+	function submitFromKeyboard() {
+		if (isGuessInputLocked()) {
+			return;
+		}
+		void handleGuess();
+	}
+
+	async function handleEnableEasyMode() {
+		if (!state || !state.isHardMode || submitting) {
+			return;
+		}
+		if (state.attempt && state.attempt.status !== 'InProgress') {
+			return;
+		}
+		error = null;
+		message = null;
+		animatedGuessId = null;
+		try {
+			state = await enableEasyMode(puzzleDate);
+			message = 'Easy mode enabled for this puzzle.';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Unable to switch to easy mode.';
+		}
+	}
+
+	function tileClass(result: LetterResult | null) {
+		const base =
+			'flex h-14 w-14 items-center justify-center rounded-xl border text-lg font-semibold transition';
+		if (result === 'Correct') {
+			return `${base} border-emerald-400 bg-emerald-400 text-slate-900 shadow-lg`;
+		}
+		if (result === 'Present') {
+			return `${base} border-amber-300/70 bg-amber-300 text-slate-900 shadow`;
+		}
+		if (result === 'Absent') {
+			return `${base} border-white/15 bg-white/5 text-white/60`;
+		}
+		return `${base} border-white/10 bg-white/5 text-white/30`;
+	}
+
+	function tileAnimationClass(guessId: string, result: LetterResult) {
+		if (guessId !== animatedGuessId) {
+			return '';
+		}
+		return `animate-reveal reveal-${result.toLowerCase()}`;
+	}
+
+	function tileAnimationDelay(guessId: string, position: number) {
+		if (guessId !== animatedGuessId) {
+			return '';
+		}
+		return `animation-delay:${position * 220}ms`;
+	}
+
+	function keyState(
+		letter: string,
+		guesses: GuessResponse[] | null | undefined
+	): LetterResult | null {
+		return getKeyboardLetterState(guesses, letter);
+	}
+
+	function keyClass(letter: string, guesses: GuessResponse[] | null | undefined) {
+		const base =
+			'flex h-11 items-center justify-center rounded-xl border px-3 text-sm font-semibold uppercase transition';
+		const stateKey = keyState(letter, guesses);
+		if (stateKey === 'Correct') {
+			return `${base} border-emerald-400 bg-emerald-400 text-slate-900`;
+		}
+		if (stateKey === 'Present') {
+			return `${base} border-amber-300/70 bg-amber-300 text-slate-900`;
+		}
+		if (stateKey === 'Absent') {
+			return `${base} border-slate-500/70 bg-slate-600 text-slate-100`;
+		}
+		return `${base} border-white/60 bg-white/90 text-slate-900 shadow hover:border-white hover:bg-white`;
+	}
+
+	function formatPuzzleDate(value: string | null | undefined) {
+		const date = value ? new Date(value) : new Date();
+		const day = String(date.getDate()).padStart(2, '0');
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const year = date.getFullYear();
+		return `${day}/${month}-${year}`;
+	}
+
+	function resetCelebration() {
+		if (confettiTimer) {
+			clearTimeout(confettiTimer);
+			confettiTimer = null;
+		}
+		showConfetti = false;
+	}
+
+	async function triggerSolveCelebration() {
+		if (!state) {
+			return;
+		}
+		resetCelebration();
+		confettiPieces = buildConfettiPieces(defaultConfettiPieceCount);
+		const revealDelayMs = getRevealDurationMs(state.wordLength ?? 5);
+		confettiTimer = setTimeout(() => {
+			showConfetti = true;
+			setTimeout(() => {
+				showConfetti = false;
+			}, confettiDurationMs);
+		}, revealDelayMs);
+	}
+</script>
+
+{#if checking}
+	<div
+		class="rounded-2xl border border-white/10 bg-white/5 p-10 text-center text-slate-200/80 shadow-xl"
+	>
+		Checking your session...
+	</div>
+{:else if $auth.user}
+	<div class="mx-auto grid max-w-6xl gap-6">
+		<section
+			class="relative rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-2xl"
+		>
+			{#if showConfetti}
+				<div class="confetti-layer" data-testid="confetti">
+					{#each confettiPieces as piece (piece.id)}
+						<span
+							class="confetti-piece"
+							style={`--dx:${piece.dx}px; --dy:${piece.dy}px; --rot:${piece.rotation}deg; --hue:${piece.hue}; --delay:${piece.delay}ms; --dur:${piece.duration}ms; --size:${piece.size}px;`}
+						></span>
+					{/each}
+				</div>
+			{/if}
+			<div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<div class="flex items-center gap-3">
+						<p class="text-sm tracking-[0.2em] text-cyan-200/80 uppercase">Replay</p>
+						<span
+							class="rounded-full border border-cyan-300/40 bg-cyan-400/10 px-2 py-0.5 text-xs font-semibold text-cyan-100"
+							>Practice</span
+						>
+					</div>
+					<h1 class="mt-2 text-3xl font-semibold text-white">
+						Puzzle for {formatPuzzleDate(state?.puzzleDate ?? puzzleDate)}
+					</h1>
+					<p class="mt-2 max-w-2xl text-sm text-slate-200/80">
+						This is a historical puzzle replay. Your results are tracked as practice and won't
+						affect your streak or leaderboard rank.
+					</p>
+				</div>
+				<div class="flex flex-col items-start gap-3 sm:items-end">
+					<span
+						class={`rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.2em] uppercase ${(state?.isHardMode ?? true) ? 'border-emerald-300/60 bg-emerald-400/10 text-emerald-100' : 'border-amber-300/50 bg-amber-400/10 text-amber-50'}`}
+					>
+						{(state?.isHardMode ?? true) ? 'Hard mode' : 'Easy mode'}
+					</span>
+					<button
+						class="rounded-full border border-white/20 bg-white/5 px-4 py-2 text-xs font-semibold tracking-[0.2em] text-white/80 uppercase transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+						onclick={handleEnableEasyMode}
+						disabled={!state ||
+							!state.isHardMode ||
+							(state.attempt && state.attempt.status !== 'InProgress') ||
+							submitting}
+						data-testid="enable-easy-mode"
+					>
+						Enable easy mode
+					</button>
+				</div>
+			</div>
+
+			{#if loadingState}
+				<div
+					class="mt-8 rounded-2xl border border-white/10 bg-black/20 p-6 text-center text-slate-200/70"
+				>
+					Loading puzzle...
+				</div>
+			{:else if state}
+				<div class="mt-6">
+					<div class="space-y-4 rounded-2xl border border-white/10 bg-black/20 p-6 shadow-inner">
+						<div class="grid grid-rows-6 gap-1.5" role="grid" aria-label="Wordle board">
+							{#each Array(state.maxGuesses).keys() as rowIndex (rowIndex)}
+								<div
+									class={`grid justify-center gap-1.5${shakingRow === rowIndex ? ' animate-shake' : ''}`}
+									style={`grid-template-columns: repeat(${state.wordLength}, 3.5rem);`}
+									data-testid={`board-row-${rowIndex}`}
+									role="row"
+									aria-label={`Guess row ${rowIndex + 1}`}
+								>
+									{#if state.attempt?.guesses[rowIndex]}
+										{#each state.attempt.guesses[rowIndex].feedback as fb (fb.position)}
+											<div
+												class={`${tileClass(fb.result)} ${tileAnimationClass(state.attempt.guesses[rowIndex].guessId, fb.result)}`}
+												style={tileAnimationDelay(
+													state.attempt.guesses[rowIndex].guessId,
+													fb.position
+												)}
+												role="gridcell"
+												aria-label={describeTileForScreenReader(fb.letter, fb.result)}
+											>
+												{fb.letter}
+											</div>
+										{/each}
+									{:else}
+										{#each Array(state.wordLength).keys() as col (col)}
+											{#if rowIndex === (state.attempt?.guesses.length ?? 0)}
+												<div
+													class={tileClass(null)}
+													role="gridcell"
+													aria-label={describeTileForScreenReader(guess[col] ?? '', null)}
+												>
+													{(guess[col] ?? '').toUpperCase()}
+												</div>
+											{:else}
+												<div
+													class={tileClass(null)}
+													role="gridcell"
+													aria-label={describeTileForScreenReader('', null)}
+												></div>
+											{/if}
+										{/each}
+									{/if}
+								</div>
+							{/each}
+						</div>
+
+						{#if announcement}
+							<div
+								class={`rounded-xl border px-4 py-3 text-sm ${announcementIsError ? 'border-rose-400/40 bg-rose-500/10 text-rose-50' : state?.attempt?.status === 'Failed' ? 'border-amber-300/40 bg-amber-400/10 text-amber-50' : 'border-emerald-300/40 bg-emerald-400/10 text-emerald-50'}`}
+								data-testid={announcementIsError ? 'error-message' : 'completed-message'}
+								role="status"
+								aria-live="polite"
+								aria-atomic="true"
+							>
+								{announcement}
+							</div>
+						{/if}
+
+						<div class="space-y-3 pt-3" role="group" aria-label="On-screen keyboard">
+							{#each keyboardRows as row, rowIndex (rowIndex)}
+								<div class="flex items-center justify-center gap-2">
+									{#if rowIndex === 2}
+										<button
+											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
+											onclick={removeLetter}
+											disabled={guessInputLocked}
+											data-testid="remove-letter"
+											aria-label="Remove letter"
+										>
+											Back
+										</button>
+									{/if}
+									{#each row.split('') as letter (letter)}
+										<button
+											class={keyClass(letter, state?.attempt?.guesses)}
+											onclick={() => pushLetter(letter)}
+											disabled={guessInputLocked}
+											data-testid={`keyboard-key-${letter}`}
+											data-state={(
+												keyState(letter, state?.attempt?.guesses) ?? 'unused'
+											).toLowerCase()}
+										>
+											{letter}
+										</button>
+									{/each}
+									{#if rowIndex === 2}
+										<button
+											class="flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-semibold tracking-[0.15em] text-white/80 uppercase transition hover:border-white/30"
+											onclick={submitFromKeyboard}
+											disabled={guessInputLocked}
+											data-testid="submit-guess"
+											aria-label="Submit guess"
+										>
+											Enter
+										</button>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				</div>
+
+				<div class="mt-6 text-center">
+					<a
+						href={resolve('/')}
+						class="text-sm text-slate-200/70 underline decoration-slate-200/30 underline-offset-4 transition hover:text-white"
+						data-testid="back-to-today"
+					>
+						Back to today's puzzle
+					</a>
+				</div>
+			{/if}
+
+			{#if !loadingState && puzzleNotFound}
+				<div
+					class="mt-8 rounded-2xl border border-amber-400/50 bg-amber-500/10 p-6 text-center text-amber-100"
+					data-testid="puzzle-not-found"
+				>
+					<p class="text-base font-semibold">No puzzle found for this date.</p>
+					<p class="mt-1 text-sm text-amber-100/80">
+						This puzzle may not exist yet, or the date is invalid.
+					</p>
+					<a
+						href={resolve('/')}
+						class="mt-4 inline-block rounded-full border border-amber-300/40 bg-amber-400/10 px-5 py-2 text-sm font-semibold text-amber-50 transition hover:bg-amber-400/20"
+					>
+						Play today's puzzle
+					</a>
+				</div>
+			{:else if !loadingState && !state && error}
+				<div
+					class="mt-8 rounded-2xl border border-rose-400/50 bg-rose-500/10 p-6 text-center text-sm text-rose-100"
+					data-testid="replay-error"
+				>
+					{error ?? 'Unable to load this puzzle.'}
+				</div>
+			{/if}
+		</section>
+	</div>
+{/if}
+
+<style>
+	:global(.animate-reveal) {
+		--start-bg: rgba(255, 255, 255, 0.08);
+		--start-border: rgba(255, 255, 255, 0.15);
+		--start-text: #e5e7eb;
+		--end-bg: rgba(255, 255, 255, 0.08);
+		--end-border: rgba(255, 255, 255, 0.15);
+		--end-text: #e5e7eb;
+		background: var(--start-bg);
+		border-color: var(--start-border);
+		color: var(--start-text);
+		animation: reveal-flip 950ms ease-in-out forwards;
+		transform-style: preserve-3d;
+	}
+
+	:global(.reveal-correct) {
+		--end-bg: #34d399;
+		--end-border: #34d399;
+		--end-text: #0f172a;
+	}
+
+	:global(.reveal-present) {
+		--end-bg: #fbbf24;
+		--end-border: #fbbf24;
+		--end-text: #0f172a;
+	}
+
+	:global(.reveal-absent) {
+		--end-bg: rgba(255, 255, 255, 0.08);
+		--end-border: rgba(255, 255, 255, 0.2);
+		--end-text: rgba(255, 255, 255, 0.6);
+	}
+
+	@keyframes reveal-flip {
+		0% {
+			transform: rotateX(-90deg) scale(0.98);
+			opacity: 0;
+			background: var(--start-bg);
+			border-color: var(--start-border);
+			color: var(--start-text);
+		}
+		50% {
+			transform: rotateX(0deg) scale(1);
+			opacity: 1;
+			background: var(--end-bg);
+			border-color: var(--end-border);
+			color: var(--end-text);
+		}
+		100% {
+			transform: rotateX(0deg);
+			opacity: 1;
+			background: var(--end-bg);
+			border-color: var(--end-border);
+			color: var(--end-text);
+		}
+	}
+
+	.confetti-layer {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		overflow: hidden;
+	}
+
+	.confetti-piece {
+		position: absolute;
+		left: 50%;
+		top: 35%;
+		width: var(--size);
+		height: calc(var(--size) * 0.7);
+		background: hsl(var(--hue) 80% 60%);
+		border-radius: 999px;
+		opacity: 0;
+		transform: translate(-50%, -50%) rotate(var(--rot));
+		animation: confetti-burst var(--dur) ease-out forwards;
+		animation-delay: var(--delay);
+	}
+
+	@keyframes confetti-burst {
+		0% {
+			transform: translate(-50%, -50%) scale(0.8) rotate(var(--rot));
+			opacity: 0;
+		}
+		15% {
+			opacity: 1;
+		}
+		100% {
+			transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot));
+			opacity: 0;
+		}
+	}
+
+	:global(.animate-shake) {
+		animation: shake 600ms ease-in-out;
+	}
+
+	@keyframes shake {
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		15% {
+			transform: translateX(-8px);
+		}
+		30% {
+			transform: translateX(7px);
+		}
+		45% {
+			transform: translateX(-6px);
+		}
+		60% {
+			transform: translateX(5px);
+		}
+		75% {
+			transform: translateX(-3px);
+		}
+		90% {
+			transform: translateX(2px);
+		}
+	}
+</style>

--- a/src/Wordle.TrackerSupreme.Web/tests/ui/replay.spec.ts
+++ b/src/Wordle.TrackerSupreme.Web/tests/ui/replay.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+
+const authedUser = {
+	id: '11111111-1111-1111-1111-111111111111',
+	displayName: 'Tester',
+	email: 'tester@example.com',
+	createdOn: '2025-01-01T00:00:00Z'
+};
+
+const replayState = {
+	puzzleDate: '2025-04-01',
+	cutoffPassed: true,
+	solutionRevealed: false,
+	allowLatePlay: true,
+	wordLength: 5,
+	maxGuesses: 6,
+	isHardMode: true,
+	canGuess: true,
+	attempt: null,
+	solution: null,
+	isReplay: true
+};
+
+async function stubAuth(page: import('@playwright/test').Page) {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('wts_auth_token', 'test-token');
+	});
+	await page.route('**/api/Auth/me', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(authedUser)
+		});
+	});
+}
+
+test('replay landing page navigates to the chosen historical puzzle', async ({ page }) => {
+	await stubAuth(page);
+
+	await page.goto('/replay', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await page.getByTestId('replay-date').fill('2025-04-01');
+
+	await page.route('**/api/game/state**', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(replayState)
+		});
+	});
+
+	await page.getByTestId('replay-submit').click();
+
+	await expect(page).toHaveURL(/\/replay\/2025-04-01$/);
+	await expect(page.getByText('Puzzle for 01/04-2025')).toBeVisible();
+	await expect(page.getByText('Practice', { exact: true })).toBeVisible();
+});
+
+test('replay page sends the date query parameter when fetching state', async ({ page }) => {
+	await stubAuth(page);
+
+	let requestedUrl: string | null = null;
+	await page.route('**/api/game/state**', async (route) => {
+		requestedUrl = route.request().url();
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(replayState)
+		});
+	});
+
+	await page.goto('/replay/2025-04-01', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect.poll(() => requestedUrl).toContain('date=2025-04-01');
+});
+
+test('replay page shows a not-found message when the puzzle is missing', async ({ page }) => {
+	await stubAuth(page);
+
+	await page.route('**/api/game/state**', async (route) => {
+		await route.fulfill({
+			status: 404,
+			contentType: 'application/json',
+			body: JSON.stringify({ message: 'No puzzle found for 2024-12-25.' })
+		});
+	});
+
+	await page.goto('/replay/2024-12-25', { waitUntil: 'domcontentloaded' });
+	await page.getByText('Loading your session...').waitFor({ state: 'hidden' });
+
+	await expect(page.getByTestId('puzzle-not-found')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Closes #28.

- Players can now play any past puzzle by visiting `/replay/<yyyy-mm-dd>`. A new `/replay` landing page provides a date picker, and a **Replay** link in the main nav makes the feature discoverable.
- The game endpoints (`GET /api/game/state`, `POST /api/game/guess`, `POST /api/game/easy-mode`) accept an optional `?date=` query parameter. Missing puzzles return `404`; future dates return `400`.
- Replay attempts go through the existing post-reveal practice path, so they're already excluded from streaks and the leaderboard without any schema changes.
- `GameStateResponse` gains an `IsReplay` flag; the replay page uses it to render a "Practice" badge and a contextual heading.

## Test plan

- [x] Backend: `docker-compose --profile tests run --rm tests-backend` — 80 passed, including 4 new replay-specific cases (existing past puzzle, missing puzzle, future date, replay submit persists attempt).
- [x] Frontend unit: `npm run -s test` — 40 passed, including 3 new tests covering the `?date=` query param on `fetchGameState`, `submitGuess`, and `enableEasyMode`.
- [x] Frontend prettier formatting clean for changed files.
- [ ] Playwright UI tests `tests/ui/replay.spec.ts` not run locally — should be exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)