### PR TITLE
Wire web build metadata into CI image builds (#123)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,10 @@ jobs:
           node-version: '20'
 
       - name: Run E2E
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          REPO_URL: https://github.com/${{ github.repository }}
         run: ./scripts/e2e.sh
 
       - name: Upload E2E artifacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,10 @@ services:
     build:
       context: ./src/Wordle.TrackerSupreme.Web
       dockerfile: Dockerfile
+      args:
+        COMMIT_SHA: ${COMMIT_SHA:-DEV}
+        BUILD_NUMBER: ${BUILD_NUMBER:-xxxxxxxx}
+        REPO_URL: ${REPO_URL:-https://github.com/HansBakN/wordle.trackersupreme}
     depends_on:
       - api
     networks:


### PR DESCRIPTION
## Summary
- pass `COMMIT_SHA`, `BUILD_NUMBER`, and `REPO_URL` into the web image build through the shared compose config
- export those values from the GitHub `e2e` workflow before `./scripts/e2e.sh` builds the app stack
- preserve local compose behavior by keeping placeholder defaults when the args are not set

Closes #123.

## Verification
- `docker-compose -f docker-compose.yml config | sed -n '/web:/,/^[^ ]/p'`
- `COMMIT_SHA=abcdef123456 BUILD_NUMBER=4242 REPO_URL=https://github.com/HansBakN/Wordle.TrackerSupreme docker-compose -f docker-compose.yml config | sed -n '/web:/,/^[^ ]/p'`
- `git diff --check`

## Notes
- I did not add the optional Playwright footer assertion here because the issue is specifically about Docker build-arg wiring; the config render checks cover the new behavior directly without broadening the frontend test harness.

🤖 Generated with Codex