### PR TITLE
[codex] Support docker-compose v1 in repo scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Apply migrations only when needed: `docker compose --env-file .env.local --profile migrate up --build migrator`
 - Seed local dev data (after migrations): `docker compose --env-file .env.local --profile seed run --rm seeder`
 - Verification wrapper: `./scripts/verify.sh all`
+- Repo scripts auto-detect `docker compose` first and fall back to legacy `docker-compose` when needed on this VM.
 - Tests (preferred):
   - Backend: `docker compose --profile tests run --rm tests-backend`
   - Frontend + UI: `docker compose --profile tests run --rm tests-frontend`
@@ -32,6 +33,7 @@
 
 ## E2E workflow (required for feature work)
 - Use the single entrypoint: `./scripts/e2e.sh` (starts backend/frontend, resets data, runs headless Playwright, writes artifacts).
+- `./scripts/e2e.sh` supports both Compose v2 and legacy `docker-compose v1`; prefer it over ad-hoc compose commands for full-stack verification.
 - After any user-visible change, you MUST:
   1) Update existing E2E tests and/or add new E2E tests covering the new behavior.
   2) Run the full E2E suite (existing + new) via `./scripts/e2e.sh`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you want one repeatable verification entrypoint from the repo root, use:
 ./scripts/verify.sh all
 ```
 Supported targets are `backend`, `frontend`, `lint`, `e2e`, and `all`.
+The repo scripts auto-detect `docker compose` first and fall back to legacy `docker-compose` when that is the only Compose CLI available.
 
 ## End-to-end (E2E) tests
 The E2E runner starts the backend + frontend, resets deterministic seed data, and runs Playwright headlessly.
@@ -92,6 +93,7 @@ Run the full E2E suite from the repo root:
 ```bash
 ./scripts/e2e.sh
 ```
+`scripts/e2e.sh` uses the same Compose auto-detection and works on both Compose v2 and legacy `docker-compose v1`.
 
 Environment overrides:
 - `BACKEND_URL` (default `http://localhost:8080`)

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/lib/compose.sh"
+FRONTEND_DIR="$ROOT_DIR/src/Wordle.TrackerSupreme.Web"
+
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/artifacts/e2e}"
 BACKEND_URL="${BACKEND_URL:-http://localhost:8080}"
 FRONTEND_URL="${FRONTEND_URL:-http://localhost:3000}"
@@ -23,7 +26,8 @@ fi
 rm -rf "$ARTIFACT_DIR"
 mkdir -p "$ARTIFACT_DIR"
 
-compose=(docker compose)
+resolve_compose_command
+compose=("${COMPOSE_CMD[@]}")
 if [[ "$is_ci" == "true" ]]; then
   compose+=(-f "$ROOT_DIR/docker-compose.yml")
 fi
@@ -58,36 +62,60 @@ FRONTEND_LOG_PID=$!
 "$ROOT_DIR/scripts/wait-for-url.sh" "$BACKEND_HEALTH_URL" 180
 "$ROOT_DIR/scripts/wait-for-url.sh" "$FRONTEND_HEALTH_URL" 180
 
-"${compose[@]}" --profile migrate run --rm --build migrator
+if compose_supports_run_build; then
+  "${compose[@]}" --profile migrate run --rm --build migrator
+else
+  "${compose[@]}" --profile migrate build migrator
+  "${compose[@]}" --profile migrate run --rm migrator
+fi
 
-E2E_RESET_ENABLED=true \
-  Seeder__AllowReseed=true \
-  Seeder__ResetDatabase=true \
-  DOTNET_ENVIRONMENT=Development \
-  "${compose[@]}" --profile seed run --rm --build \
-  -e E2E_RESET_ENABLED=true \
-  -e Seeder__AllowReseed=true \
-  -e Seeder__ResetDatabase=true \
-  -e DOTNET_ENVIRONMENT=Development \
-  seeder
+if compose_supports_run_build; then
+  E2E_RESET_ENABLED=true \
+    Seeder__AllowReseed=true \
+    Seeder__ResetDatabase=true \
+    DOTNET_ENVIRONMENT=Development \
+    "${compose[@]}" --profile seed run --rm --build \
+    -e E2E_RESET_ENABLED=true \
+    -e Seeder__AllowReseed=true \
+    -e Seeder__ResetDatabase=true \
+    -e DOTNET_ENVIRONMENT=Development \
+    seeder
+else
+  "${compose[@]}" --profile seed build seeder
+  E2E_RESET_ENABLED=true \
+    Seeder__AllowReseed=true \
+    Seeder__ResetDatabase=true \
+    DOTNET_ENVIRONMENT=Development \
+    "${compose[@]}" --profile seed run --rm \
+    -e E2E_RESET_ENABLED=true \
+    -e Seeder__AllowReseed=true \
+    -e Seeder__ResetDatabase=true \
+    -e DOTNET_ENVIRONMENT=Development \
+    seeder
+fi
 
 export E2E_BASE_URL
 export E2E_ARTIFACT_DIR="$ARTIFACT_DIR/playwright"
 
-if [[ "$is_ci" == "true" ]]; then
-  if [[ -d "$ROOT_DIR/src/Wordle.TrackerSupreme.Web/node_modules" ]]; then
-    if command -v sudo >/dev/null 2>&1; then
-      sudo rm -rf "$ROOT_DIR/src/Wordle.TrackerSupreme.Web/node_modules"
-    else
-      rm -rf "$ROOT_DIR/src/Wordle.TrackerSupreme.Web/node_modules"
-    fi
-  fi
-  (cd "$ROOT_DIR/src/Wordle.TrackerSupreme.Web" && npm ci)
-elif [[ ! -d "$ROOT_DIR/src/Wordle.TrackerSupreme.Web/node_modules" ]]; then
-  (cd "$ROOT_DIR/src/Wordle.TrackerSupreme.Web" && npm ci)
+playwright_cli="$FRONTEND_DIR/node_modules/.bin/playwright"
+needs_frontend_install=false
+
+if [[ "$is_ci" == "true" || ! -x "$playwright_cli" ]]; then
+  needs_frontend_install=true
 fi
 
-(cd "$ROOT_DIR/src/Wordle.TrackerSupreme.Web" && {
+if [[ "$needs_frontend_install" == "true" ]]; then
+  if [[ -d "$FRONTEND_DIR/node_modules" ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo rm -rf "$FRONTEND_DIR/node_modules"
+    else
+      rm -rf "$FRONTEND_DIR/node_modules"
+    fi
+  fi
+  (cd "$FRONTEND_DIR" && npm ci)
+fi
+
+(cd "$FRONTEND_DIR" && {
   if [[ "$is_ci" == "true" && "$(uname -s)" == "Linux" ]]; then
     if command -v sudo >/dev/null 2>&1; then
       sudo npx playwright install-deps chromium

--- a/scripts/lib/compose.sh
+++ b/scripts/lib/compose.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+resolve_compose_command() {
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+    return 0
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+    return 0
+  fi
+
+  echo "Neither 'docker compose' nor 'docker-compose' is available." >&2
+  return 1
+}
+
+compose_supports_run_build() {
+  if [[ "${COMPOSE_CMD[0]}" == "docker-compose" ]]; then
+    return 1
+  fi
+
+  local help_text
+  help_text="$("${COMPOSE_CMD[@]}" run --help 2>/dev/null || true)"
+
+  if [[ "$help_text" == *"--build"* ]]; then
+    return 0
+  fi
+
+  return 1
+}

--- a/scripts/tests/test_compose_compat.py
+++ b/scripts/tests/test_compose_compat.py
@@ -1,0 +1,126 @@
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ComposeCompatTests(unittest.TestCase):
+    def make_stub_bin(self, temp_dir: Path) -> Path:
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+
+        stubs = {
+            "docker": """#!/usr/bin/env bash
+set -euo pipefail
+echo "docker:$*" >> "$COMMAND_LOG"
+if [[ "${1:-}" == "compose" ]]; then
+  echo "docker: unknown command: docker compose" >&2
+  exit 1
+fi
+exit 0
+""",
+            "docker-compose": """#!/usr/bin/env bash
+set -euo pipefail
+echo "docker-compose:$*" >> "$COMMAND_LOG"
+if [[ "${1:-}" == "logs" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "build" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "run" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "--build" ]]; then
+      echo "run --build is unsupported in docker-compose v1" >&2
+      exit 99
+    fi
+  done
+  exit 0
+fi
+exit 0
+""",
+            "curl": """#!/usr/bin/env bash
+printf '200'
+exit 0
+""",
+            "npm": """#!/usr/bin/env bash
+set -euo pipefail
+echo "npm:$*" >> "$COMMAND_LOG"
+exit 0
+""",
+            "npx": """#!/usr/bin/env bash
+set -euo pipefail
+echo "npx:$*" >> "$COMMAND_LOG"
+exit 0
+""",
+            "sudo": """#!/usr/bin/env bash
+set -euo pipefail
+"$@"
+""",
+        }
+
+        for name, content in stubs.items():
+            path = bin_dir / name
+            path.write_text(textwrap.dedent(content))
+            path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+        return bin_dir
+
+    def run_script(self, args: list[str], temp_dir: Path) -> subprocess.CompletedProcess[str]:
+        command_log = temp_dir / "commands.log"
+        artifact_dir = temp_dir / "artifacts"
+        bin_dir = self.make_stub_bin(temp_dir)
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["COMMAND_LOG"] = str(command_log)
+        env["ARTIFACT_DIR"] = str(artifact_dir)
+        env["BACKEND_HEALTH_URL"] = "http://example.invalid/backend"
+        env["FRONTEND_HEALTH_URL"] = "http://example.invalid/frontend"
+        env["E2E_BASE_URL"] = "http://example.invalid"
+        env["CI"] = "false"
+
+        return subprocess.run(
+            args,
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_e2e_script_falls_back_to_docker_compose_v1_without_run_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            temp_dir = Path(temp)
+            result = self.run_script(["bash", "scripts/e2e.sh"], temp_dir)
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            command_log = (temp_dir / "commands.log").read_text()
+            self.assertIn("docker:compose version", command_log)
+            self.assertIn("docker-compose:--profile app up -d --build db api web", command_log)
+            self.assertIn("build migrator", command_log)
+            self.assertIn("build seeder", command_log)
+            self.assertIn("run --rm migrator", command_log)
+            self.assertIn("run --rm -e E2E_RESET_ENABLED=true", command_log)
+            self.assertNotIn("--build migrator", command_log)
+            self.assertNotIn("run --rm --build", command_log)
+
+    def test_verify_backend_uses_compose_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            temp_dir = Path(temp)
+            result = self.run_script(["bash", "scripts/verify.sh", "backend"], temp_dir)
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            command_log = (temp_dir / "commands.log").read_text()
+            self.assertIn("docker:compose version", command_log)
+            self.assertIn("docker-compose:--profile tests run --rm tests-backend", command_log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FRONTEND_DIR="$ROOT_DIR/src/Wordle.TrackerSupreme.Web"
+source "$ROOT_DIR/scripts/lib/compose.sh"
+
+resolve_compose_command
+compose=("${COMPOSE_CMD[@]}")
 
 usage() {
   cat <<'EOF'
@@ -18,11 +22,11 @@ EOF
 }
 
 run_backend() {
-  docker compose --profile tests run --rm tests-backend
+  "${compose[@]}" --profile tests run --rm tests-backend
 }
 
 run_frontend() {
-  docker compose --profile tests run --rm tests-frontend
+  "${compose[@]}" --profile tests run --rm tests-frontend
 }
 
 run_lint() {


### PR DESCRIPTION
## Summary
- add a shared Compose command resolver so repo scripts use `docker compose` when available and fall back to legacy `docker-compose`
- make `scripts/e2e.sh` build `migrator` and `seeder` explicitly before `run --rm` when the active Compose CLI does not support `run --build`
- reinstall frontend dependencies when the Playwright CLI is missing instead of trusting the presence of `node_modules`
- document the script-level Compose compatibility in `README.md` and `AGENTS.md`
- add script-level regression coverage for the Compose fallback behavior

## Why
The dedicated Codex VM only has `docker-compose v1`, while `scripts/e2e.sh` and `scripts/verify.sh` assumed `docker compose` and `run --build`. That prevented the required repo verification entrypoints from working on the supported local worker environment.

## Verification
- `python3 -m unittest scripts.tests.test_compose_compat -v`
- `bash -n scripts/e2e.sh scripts/verify.sh scripts/lib/compose.sh`
- `git diff --check`
- `./scripts/verify.sh backend`
- `./scripts/e2e.sh`
  - on this VM the script now gets through app startup, migrations, reseeding, frontend dependency install, browser install, and into the real Playwright suite under `docker-compose v1`
  - the run is still blocked by existing E2E test failures in unrelated specs including `tests/e2e/admin.spec.ts`, `tests/e2e/auth-flow.spec.ts`, `tests/e2e/game-duplicate-attempt.spec.ts`, and `tests/e2e/game-easy-mode.spec.ts`

## Issue
Refs #126.

🤖 Generated with Codex